### PR TITLE
Move input field on session lock to the bottom

### DIFF
--- a/.config/hypr/hyprlock.conf
+++ b/.config/hypr/hyprlock.conf
@@ -38,9 +38,9 @@ input-field {
     fail_text = <i>$FAIL <b>($ATTEMPTS)</b></i>
     hide_input = false
     
-    position = 0, 20
+    position = 0, 120
     halign = center
-    valign = center
+    valign = bottom
     
     # Shadow for the input field
     shadow_passes = 2


### PR DESCRIPTION
Just a small change that I personally think makes the experience just that little bit nicer
### Before
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/37348ec4-965e-46d9-8a6c-dd84a3afed69" />

### After
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/137e82fd-e0ef-4071-b2a4-b3735c29510c" />
