### PR TITLE
feat(zsh): add automatic fastfetch execution for interactive shells

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -494,6 +494,11 @@ if [[ -z "$DISPLAY" ]] && [[ "$(tty)" == "/dev/tty1" ]]; then
   fi
 fi
 
+# Start fastfetch if installed and in an interactive shell
+if [[ $- == *i* ]] && command -v fastfetch &> /dev/null; then
+    fastfetch
+fi
+
 # =============================================================================
 # End of ~/.zshrc
 # =============================================================================


### PR DESCRIPTION
Fixes #12

Summary

This PR addresses Issue #12 by adding logic to the shell configuration (.zshrc) to automatically execute fastfetch upon terminal startup.
Changes

Added a conditional check in .zshrc to verify if the shell is interactive and if the fastfetch binary exists before execution.

 Ensures that users who have fastfetch installed get the visual "fetch" output automatically in Kitty (or other terminals), while users without the binary see no errors.