### PR TITLE
Improved the notification when wallpaper cache refreshing

### DIFF
--- a/user_scripts/rofi/rofi_wallpaper_selctor.sh
+++ b/user_scripts/rofi/rofi_wallpaper_selctor.sh
@@ -77,7 +77,7 @@ cleanup_orphans() {
 }
 
 refresh_cache() {
-    notify-send -a "Wallpaper Menu" "Refreshing cache" "Please wait. CPU usage may be high during this process." -u low -t 1000
+    notify-send -a "Wallpaper Menu" "Refreshing Wallpaper cache" "Please wait. CPU usage may be high during this process." -u low -t 1000
     ensure_placeholder
     
     # 1. Update Thumbnails (Parallel)


### PR DESCRIPTION
I've noticed that while the wallpaper cache gets refreshed, the CPU usage spikes. Since this might confuse some people, I've thought to add a small note to the notification that appears when the cache refresh is starts. Once again a pretty small change, but one that I think improves the general user experience a fair bit.

# Before (top) and After (bottom)
<img width="450" height="240" alt="image" src="https://github.com/user-attachments/assets/1d89009c-4259-4152-8a79-6fd932986027" />