### PR TITLE
Added Minecraft specific window rules

### DIFF
--- a/.config/hypr/source/window_rules.conf
+++ b/.config/hypr/source/window_rules.conf
@@ -186,12 +186,18 @@ windowrule {
 #}
 
 # -------------------------------------------------
-# PRISM LAUNCHER (Minecraft)
+# PRISM LAUNCHER AND MINECRAFT
 # -------------------------------------------------
 windowrule {
   name = PrismLauncher
   match:class = org.prismlauncher.PrismLauncher
   float = on
+}
+
+windowrule {
+  name = Minecraft
+  match:class = com.mojang.minecraft.java-edition
+  opaque = on
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
I've added window rules for Minecraft and PrismLauncher. PrismLauncher is a 3rd party Minecraft Launcher that I use, and since it is a game launcher (just like Steam), I thought it'd be better to make it float by default. For the actual game, I've just created a window rule that makes the window opaque by default.
