### PR TITLE
Fix spelling mistake in Keybindings LIst

### DIFF
--- a/.config/hypr/source/keybinds.conf
+++ b/.config/hypr/source/keybinds.conf
@@ -30,7 +30,7 @@ bindd = CTRL SHIFT, SPACE, Show Keybinds, exec, uwsm-app -- pkill rofi; $scripts
 bindd = $mainMod CTRL, SPACE, Search Emojis, exec, uwsm-app -- pkill rofi; $scripts/rofi/emoji.sh
 bindd = $mainMod CTRL SHIFT, SPACE, Calculator, exec, uwsm-app -- pkill rofi; $scripts/rofi/calculator.sh
 bindd = $mainMod SHIFT, SPACE, Matugen Theme Config, exec, uwsm-app -- pkill rofi; $scripts/theme_matugen/matugen_config.sh
-bindd = CTRL, SPACE, Rofi Wallaper Selector, exec, uwsm-app -- pkill rofi; $scripts/rofi/rofi_wallpaper_selctor.sh
+bindd = CTRL, SPACE, Rofi Wallpaper Selector, exec, uwsm-app -- pkill rofi; $scripts/rofi/rofi_wallpaper_selctor.sh
 bindd = $mainMod, SPACE, System Menu, exec, uwsm-app -- pkill rofi; $scripts/rofi/system_menu.sh
 bindd = CTRL ALT, SPACE, UWSM uuctl - display active user units, exec, uwsm-app -- pkill rofi; uuctl
 


### PR DESCRIPTION
"Rofi Wallpaper List" used to be written as "Rofi Wallaper List", so I fixed that real quick.