### PR TITLE
Fix: fixed updates available icon to check for both paru and yay. 

### DIFF
--- a/.config/waybar/horizontal_block/config.jsonc
+++ b/.config/waybar/horizontal_block/config.jsonc
@@ -94,7 +94,7 @@
     "format": " {}",
     "exec": "checkupdates 2>/dev/null | wc -l || echo 0", 
     "interval": 3600,
-    "on-click": "kitty -e yay", 
+    "on-click": "kitty sh -c 'command -v yay >/dev/null && yay || paru'", 
     "tooltip-format": "Updates Available"
   },
   "idle_inhibitor": {


### PR DESCRIPTION
Update icon was only checking for yay now it checks for both paru and yay
