### PR TITLE
Uncomment label configuration in hyprlock.conf

### DIFF
--- a/.config/hypr/hyprlock_themes/006_stacked_clock/hyprlock.conf
+++ b/.config/hypr/hyprlock_themes/006_stacked_clock/hyprlock.conf
@@ -97,7 +97,7 @@ label {
 }
 
 # USER
-#label {
+label {
     monitor =
     text = $USER
     color = $text_color


### PR DESCRIPTION
removed the # on like 100 infront of label { 
would cause screen locker to not work
# Lines 100-109
#label {              ← Opening brace COMMENTED OUT
    monitor =
    text = $USER
    color = $text_color
    font_size = 14
    font_family = JetBrainsMono NFM Bold
    position = 0, 200
    halign = center
    valign = bottom
}                      ← Closing brace ACTIVE - parser error!