### PR TITLE
Added opaque window rules for Figma and Pixabay in Firefox

### DIFF
--- a/.config/hypr/source/window_rules.conf
+++ b/.config/hypr/source/window_rules.conf
@@ -121,6 +121,24 @@ windowrule {
     opaque = on
 }
 
+#--- Firefox: Figma Full Opacity ---
+# Forces 100% opacity (no transparency/dimming) specifically for Figma (A web based UI Design tool)
+windowrule {
+    name = opaque-firefox-figma
+    match:class = ^(firefox)$
+    match:title = .*Figma.*
+    opaque = on
+}
+
+#--- Firefox: Pixabay Full Opacity ---
+# Forces 100% opacity (no transparency/dimming) specifically for Figma (A web based UI Design tool)
+windowrule {
+    name = opaque-firefox-pixabay
+    match:class = ^(firefox)$
+    match:title = .*Pixabay.*
+    opaque = on
+}
+
 #--- Opaque Rules for Specific Apps (Commented Out) ---
 # These are kept as-is from your backup. Uncomment to force global opacity for
 # the matching app class.


### PR DESCRIPTION
Figma is a web-based graphic design tool for UI/UX, so it's better if people see the actual color instead of a wallpaper-tinted version. Meanwhile Pixabay is a massive image library, so having the images not tinted is also a win.