### PR TITLE
Fixed crash from invalid use of utility.save_settings

### DIFF
--- a/user_scripts/dusky_system/control_center/lib/rows.py
+++ b/user_scripts/dusky_system/control_center/lib/rows.py
@@ -740,7 +740,7 @@ class ToggleRow(StateMonitorMixin, BaseActionRow):
 
         if key := self.properties.get("key"):
             utility.save_setting(
-                str(key).strip(), state ^ self.key_inverse, self.save_as_int
+                str(key).strip(), state ^ self.key_inverse, as_int=self.save_as_int
             )
 
         return False


### PR DESCRIPTION
The call for `utility.save_settings` in line 1207 was outdated and causing this error which crashed the GUI. After changing it, it now works. Would be nice to remove the as_int property entirely in the future by the way.

<img width="1187" height="225" alt="image" src="https://github.com/user-attachments/assets/635f0a2d-4781-4e40-9c92-799c77bc03cd" />
