### PR TITLE
Set minimum value for brightness slider in the Control Center to 1

### DIFF
--- a/user_scripts/dusky_system/control_center/dusky_config.yaml
+++ b/user_scripts/dusky_system/control_center/dusky_config.yaml
@@ -92,7 +92,7 @@ pages:
       properties:
         title: Brightness
         icon: display-brightness-high-symbolic
-        min: 0
+        min: 1
         max: 100
         step: 1
         default: 50


### PR DESCRIPTION
The reason why I think this change is necessary is because for some laptops (including both my Wortmann Terra Mobile 1515 and my Dell Latitude 5300 2-in-1), setting the brightness to 0% turns off the display entirely which I don't think is very usable.