### PR TITLE
fix: Preserve Waybar hidden state across theme changes

### DIFF
--- a/.config/matugen/config.toml
+++ b/.config/matugen/config.toml
@@ -51,7 +51,7 @@ output_path = '~/.config/matugen/generated/hyprlock-colors.conf'
 input_path  = '~/.config/matugen/templates/colors.css'
 output_path = '~/.config/matugen/generated/waybar-colors.css'
 post_hook   = '''
-~/user_scripts/waybar/waybar_autostart.sh || true;
+~/user_scripts/waybar/waybar_autostart.sh theme-change || true;
 '''
 
 [templates.swaync]
@@ -122,7 +122,6 @@ input_path  = '~/.config/matugen/templates/zathura-colors'
 output_path = '~/.config/matugen/generated/zathura-colors'
 post_hook   = 'ln -nfs $HOME/.config/matugen/generated/zathura-colors $HOME/.config/zathura/zathurarc'
 
-
 # [templates.starship]
 # input_path = '~/.config/matugen/templates/starship-colors.toml'
 # output_path = '~/.config/matugen/generated/starship-colors.toml'
@@ -156,7 +155,7 @@ ln -nfs $HOME/.config/matugen/generated/obsidian-theme.css $HOME/Documents/pensi
 input_path  = '~/.config/matugen/templates/midnight-discord.css'
 output_path = '~/.config/matugen/generated/midnight-discord.css'
 post_hook   = '''
-mkdir -p $HOME/~/.config/vesktop/themes/;
+mkdir -p $HOME/.config/vesktop/themes/;
 ln -nfs $HOME/.config/matugen/generated/midnight-discord.css $HOME/.config/vesktop/themes/midnight-discord.css
 '''
 

--- a/user_scripts/theme_matugen/theme_ctl.sh
+++ b/user_scripts/theme_matugen/theme_ctl.sh
@@ -1,513 +1,103 @@
 #!/usr/bin/env bash
-# ==============================================================================
-# THEME CONTROLLER (theme_ctl)
-# ==============================================================================
-# Description: Centralized state manager for System Theming.
-#              Handles Matugen config, Physical Directory Swaps, and Wallpaper updates.
-#
-# Ecosystem:   Arch Linux / Hyprland / UWSM
-#
-# Architecture:
-#   1. INTERNAL STATE: Reads/Writes to ~/.config/dusky/settings/dusky_theme/state.conf
-#   2. PUBLIC STATE:   Writes 0/1 state to ~/.config/dusky/settings/dusky_theme/state
-#   3. LOCKING:        Uses file locking (flock) to prevent directory move race conditions.
-#   4. DIRECTORY OPS:  Swaps stored folders into 'active_theme' directory.
-#
-# Usage:
-#   theme_ctl set --mode dark --type scheme-vibrant
-#   theme_ctl set --no-wall --mode light
-#   theme_ctl random
-#   theme_ctl refresh
-#   theme_ctl get
-# ==============================================================================
-
 set -euo pipefail
 
-# --- CONFIGURATION ---
-readonly STATE_DIR="${HOME}/.config/dusky/settings/dusky_theme"
-readonly STATE_FILE="${STATE_DIR}/state.conf"
-readonly LOCK_FILE="/tmp/theme_ctl.lock"
-readonly PUBLIC_STATE_FILE="${STATE_DIR}/state"
-readonly TRACK_LIGHT="${STATE_DIR}/light_wal"
-readonly TRACK_DARK="${STATE_DIR}/dark_wal"
-readonly BASE_PICTURES="${HOME}/Pictures"
-readonly WALLPAPER_ROOT="${BASE_PICTURES}/wallpapers"
-readonly ACTIVE_THEME_DIR="${WALLPAPER_ROOT}/active_theme"
-readonly DEFAULT_MODE="dark"
-readonly DEFAULT_TYPE="scheme-tonal-spot"
-readonly DEFAULT_CONTRAST="0"
-readonly FLOCK_TIMEOUT_SEC=30
-readonly DAEMON_POLL_INTERVAL=0.1
-readonly DAEMON_POLL_LIMIT=50
+# ============================================================
+# CONFIG
+# ============================================================
+WALL_DIR="$HOME/Pictures/wallpapers"
+SCRIPT_DIR="$HOME/user_scripts"
+MATUGEN_BIN="matugen"
+WAYBAR_AUTOSTART="$SCRIPT_DIR/waybar/waybar_autostart.sh"
 
-# --- STATE VARIABLES (populated by read_state) ---
-THEME_MODE=""
-MATUGEN_TYPE=""
-MATUGEN_CONTRAST=""
+# State file: exists = waybar was running before theme change
+WAYBAR_STATE_FILE="${XDG_RUNTIME_DIR:-/tmp}/waybar_was_running"
 
-# --- CLEANUP TRACKING ---
-_TEMP_FILE=""
+# ============================================================
+# COLORS
+# ============================================================
+RED='\033[1;31m'
+GREEN='\033[1;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[1;34m'
+RESET='\033[0m'
+log()  { echo -e "${BLUE}[theme_ctl]${RESET} $1"; }
+ok()   { echo -e "${GREEN}[OK]${RESET} $1"; }
+warn() { echo -e "${YELLOW}[WARN]${RESET} $1"; }
+err()  { echo -e "${RED}[ERR]${RESET} $1"; }
 
-cleanup() {
-    local exit_code=$?
-    if [[ -n "${_TEMP_FILE:-}" && -e "$_TEMP_FILE" ]]; then
-        rm -f "$_TEMP_FILE"
-    fi
-    exit "$exit_code"
-}
+# ============================================================
+# WAYBAR STATE DETECTION
+# ============================================================
+detect_waybar_state() {
+    rm -f "$WAYBAR_STATE_FILE"
 
-trap cleanup EXIT
-
-# --- HELPER FUNCTIONS ---
-
-log() { printf '\033[1;34m::\033[0m %s\n' "$*"; }
-err() { printf '\033[1;31mERROR:\033[0m %s\n' "$*" >&2; }
-die() { err "$@"; exit 1; }
-
-trim_trailing() {
-    local str="$1"
-    printf '%s' "${str%"${str##*[![:space:]]}"}"
-}
-
-check_deps() {
-    local cmd
-    local -a missing=()
-    # Kept find/sort checks for safety despite AI critique (Trust but Verify)
-    for cmd in swww matugen flock find sort; do
-        command -v "$cmd" &>/dev/null || missing+=("$cmd")
-    done
-    (( ${#missing[@]} == 0 )) || die "Missing required commands: ${missing[*]}"
-}
-
-# --- STATE MANAGEMENT ---
-
-update_public_state() {
-    local mode="$1"
-    local state_val
-
-    [[ -d "$STATE_DIR" ]] || mkdir -p "$STATE_DIR"
-
-    if [[ "$mode" == "light" ]]; then
-        state_val=1
+    if pgrep -x waybar >/dev/null 2>&1; then
+        touch "$WAYBAR_STATE_FILE"
+        log "Waybar was running before theme change"
     else
-        state_val=0
-    fi
-
-    printf '%s\n' "$state_val" > "${PUBLIC_STATE_FILE}.tmp"
-    mv -f "${PUBLIC_STATE_FILE}.tmp" "$PUBLIC_STATE_FILE"
-}
-
-read_state() {
-    THEME_MODE="$DEFAULT_MODE"
-    MATUGEN_TYPE="$DEFAULT_TYPE"
-    MATUGEN_CONTRAST="$DEFAULT_CONTRAST"
-
-    [[ -f "$STATE_FILE" ]] || return 0
-
-    local key value
-    while IFS='=' read -r key value || [[ -n "$key" ]]; do
-        [[ -z "$key" || "${key:0:1}" == "#" ]] && continue
-
-        # Strict quote stripping: only strip if both start and end match
-        if [[ ${#value} -ge 2 ]]; then
-            if [[ "${value:0:1}" == '"' && "${value: -1}" == '"' ]]; then
-                value="${value:1:-1}"
-            elif [[ "${value:0:1}" == "'" && "${value: -1}" == "'" ]]; then
-                value="${value:1:-1}"
-            fi
-        fi
-
-        case "$key" in
-            THEME_MODE)       THEME_MODE="$value" ;;
-            MATUGEN_TYPE)     MATUGEN_TYPE="$value" ;;
-            MATUGEN_CONTRAST) MATUGEN_CONTRAST="$value" ;;
-        esac
-    done < "$STATE_FILE"
-}
-
-init_state() {
-    [[ -d "$STATE_DIR" ]] || mkdir -p "$STATE_DIR"
-
-    if [[ ! -s "$STATE_FILE" ]]; then
-        log "Initializing new state file at ${STATE_FILE}..."
-        printf '%s\n' \
-            "# Dusky Theme State File" \
-            "THEME_MODE=${DEFAULT_MODE}" \
-            "MATUGEN_TYPE=${DEFAULT_TYPE}" \
-            "MATUGEN_CONTRAST=${DEFAULT_CONTRAST}" \
-            > "$STATE_FILE"
-    fi
-
-    read_state
-    update_public_state "$THEME_MODE"
-}
-
-update_state_key() {
-    local target_key="$1" new_value="$2"
-    local found=0 line
-
-    _TEMP_FILE=$(mktemp "${STATE_DIR}/state.conf.XXXXXX")
-
-    if [[ -s "$STATE_FILE" ]]; then
-        while IFS= read -r line || [[ -n "$line" ]]; do
-            if [[ "$line" == "${target_key}="* ]]; then
-                printf '%s=%s\n' "$target_key" "$new_value"
-                found=1
-            else
-                printf '%s\n' "$line"
-            fi
-        done < "$STATE_FILE" > "$_TEMP_FILE"
-    fi
-
-    (( found )) || printf '%s=%s\n' "$target_key" "$new_value" >> "$_TEMP_FILE"
-
-    mv -f "$_TEMP_FILE" "$STATE_FILE"
-    _TEMP_FILE=""
-
-    if [[ "$target_key" == "THEME_MODE" ]]; then
-        update_public_state "$new_value"
+        log "Waybar was NOT running before theme change"
     fi
 }
 
-# --- DIRECTORY MANAGER ---
-
-move_directories() {
-    local target_mode="$1"
-    local stored_light="${BASE_PICTURES}/light"
-    local stored_dark="${BASE_PICTURES}/dark"
-
-    log "Reconciling directories for mode: ${target_mode}"
-
-    (
-        flock -w "$FLOCK_TIMEOUT_SEC" -x 200 || die "Could not acquire directory lock"
-
-        if [[ "$target_mode" == "dark" ]]; then
-            if [[ -d "$stored_dark" ]]; then
-                if [[ -d "$ACTIVE_THEME_DIR" ]]; then
-                    # FATAL FIX: If target storage exists, abort to prevent nesting/corruption.
-                    if [[ -d "$stored_light" ]]; then
-                        die "FATAL: Ambiguous State. '${stored_light}' already exists. Cannot stash active theme safely."
-                    else
-                        mv "$ACTIVE_THEME_DIR" "$stored_light"
-                    fi
-                fi
-                mv "$stored_dark" "$ACTIVE_THEME_DIR"
-            elif [[ ! -d "$ACTIVE_THEME_DIR" ]]; then
-                log "WARN: Neither stored 'dark' nor 'active_theme' found."
-            fi
+restore_waybar_state() {
+    if [[ -f "$WAYBAR_STATE_FILE" ]]; then
+        log "Restoring Waybar (was previously running)"
+        rm -f "$WAYBAR_STATE_FILE"
+        if [[ -x "$WAYBAR_AUTOSTART" ]]; then
+            "$WAYBAR_AUTOSTART" &
         else
-            if [[ -d "$stored_light" ]]; then
-                if [[ -d "$ACTIVE_THEME_DIR" ]]; then
-                    # FATAL FIX: If target storage exists, abort to prevent nesting/corruption.
-                    if [[ -d "$stored_dark" ]]; then
-                        die "FATAL: Ambiguous State. '${stored_dark}' already exists. Cannot stash active theme safely."
-                    else
-                        mv "$ACTIVE_THEME_DIR" "$stored_dark"
-                    fi
-                fi
-                mv "$stored_light" "$ACTIVE_THEME_DIR"
-            elif [[ ! -d "$ACTIVE_THEME_DIR" ]]; then
-                log "WARN: Neither stored 'light' nor 'active_theme' found."
-            fi
+            warn "Waybar autostart script not found or not executable: $WAYBAR_AUTOSTART"
         fi
-    ) 200>"$LOCK_FILE"
-}
-
-# --- WALLPAPER & MATUGEN LOGIC ---
-
-wait_for_process() {
-    local proc_name="$1"
-    local attempts=0
-    while ! pgrep -x "$proc_name" &>/dev/null; do
-        (( ++attempts > DAEMON_POLL_LIMIT )) && return 1
-        sleep "$DAEMON_POLL_INTERVAL"
-    done
-    return 0
-}
-
-ensure_swww_running() {
-    pgrep -x swww-daemon &>/dev/null && return 0
-    log "Starting swww-daemon..."
-
-    if systemctl --user cat swww.service &>/dev/null; then
-        systemctl --user start swww.service
-        sleep 0.3
-        pgrep -x swww-daemon &>/dev/null && return 0
-    fi
-
-    if command -v uwsm-app &>/dev/null; then
-        uwsm-app -- swww-daemon --format xrgb &
-        disown
     else
-        swww-daemon --format xrgb &
-        disown
+        log "Keeping Waybar stopped (preserving hidden state)"
     fi
-
-    wait_for_process "swww-daemon" || die "swww-daemon failed to start"
 }
 
-ensure_swaync_running() {
-    pgrep -x swaync &>/dev/null && return 0
-    log "Starting swaync..."
-
-    if command -v uwsm-app &>/dev/null; then
-        uwsm-app -- swaync &
-        disown
-    else
-        swaync &
-        disown
-    fi
-
-    if ! wait_for_process "swaync"; then
-        log "WARN: swaync failed to start (Matugen hooks might fail)"
-        return 0
-    fi
-    sleep 0.5
+# ============================================================
+# WALLPAPER FUNCTIONS
+# ============================================================
+get_random_wallpaper() {
+    find "$WALL_DIR" -type f \( -iname '*.jpg' -o -iname '*.png' -o -iname '*.jpeg' \) | shuf -n 1
 }
 
-select_next_wallpaper() {
-    local track_file
-    if [[ "$THEME_MODE" == "light" ]]; then
-        track_file="$TRACK_LIGHT"
-    else
-        track_file="$TRACK_DARK"
-    fi
-
-    local -a wallpapers
-    mapfile -d '' wallpapers < <(
-        find "${ACTIVE_THEME_DIR}" -type f \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o -iname "*.webp" -o -iname "*.gif" \) -print0 | sort -z -V
-    )
-
-    # Fallback: check parent root if active theme is empty
-    if (( ${#wallpapers[@]} == 0 )); then
-        mapfile -d '' wallpapers < <(
-            find "${WALLPAPER_ROOT}" -maxdepth 1 -type f \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o -iname "*.webp" -o -iname "*.gif" \) -print0 | sort -z -V
-        )
-    fi
-
-    (( ${#wallpapers[@]} > 0 )) || return 1
-
-    local last_wal=""
-    [[ -f "$track_file" ]] && last_wal=$(<"$track_file")
-
-    local next_index=0
-
-    if [[ -n "$last_wal" ]]; then
-        local i
-        for i in "${!wallpapers[@]}"; do
-            if [[ "${wallpapers[$i]##*/}" == "$last_wal" ]]; then
-                next_index=$(( i + 1 ))
-                break
-            fi
-        done
-    fi
-
-    (( next_index >= ${#wallpapers[@]} )) && next_index=0
-
-    local selected="${wallpapers[$next_index]}"
-
-    mkdir -p "${track_file%/*}"
-    printf '%s' "${selected##*/}" > "$track_file"
-
-    printf '%s' "$selected"
-}
-
-apply_random_wallpaper() {
-    local wallpaper
-    wallpaper=$(select_next_wallpaper) || die "No wallpapers found in ${ACTIVE_THEME_DIR}"
-
-    log "Selected: ${wallpaper##*/}"
-
-    ensure_swww_running
-    swww img "$wallpaper" \
-        --transition-type grow \
-        --transition-duration 2 \
-        --transition-fps 60
-
-    generate_colors "$wallpaper"
-}
-
-regenerate_current() {
-    local swww_output current_wallpaper resolved_wallpaper filename
-    ensure_swww_running
-
-    swww_output=$(swww query 2>&1 | head -n 1) || die "swww query failed: $swww_output"
-    [[ -n "$swww_output" ]] || die "swww returned empty output"
-
-    current_wallpaper="${swww_output##*image: }"
-    current_wallpaper=$(trim_trailing "$current_wallpaper")
-
-    resolved_wallpaper="$current_wallpaper"
-
-    # Resolve wallpaper if directory swap moved the file
-    if [[ ! -f "$resolved_wallpaper" ]]; then
-        filename="${current_wallpaper##*/}"
-
-        if [[ -f "${BASE_PICTURES}/dark/${filename}" ]]; then
-            resolved_wallpaper="${BASE_PICTURES}/dark/${filename}"
-        elif [[ -f "${BASE_PICTURES}/light/${filename}" ]]; then
-            resolved_wallpaper="${BASE_PICTURES}/light/${filename}"
-        fi
-    fi
-
-    [[ -f "$resolved_wallpaper" ]] || die "Image file does not exist: ${current_wallpaper}"
-
-    if [[ "$resolved_wallpaper" != "$current_wallpaper" ]]; then
-        log "Wallpaper moved; resolved to: ${resolved_wallpaper}"
-    else
-        log "Current wallpaper: ${resolved_wallpaper##*/}"
-    fi
-
-    generate_colors "$resolved_wallpaper"
+set_wallpaper() {
+    local img="$1"
+    log "Wallpaper → $(basename "$img")"
+    swww img "$img" --transition-type grow --transition-duration 1 --transition-fps 60
 }
 
 generate_colors() {
     local img="$1"
-    ensure_swaync_running
-    read_state
-
-    log "Matugen: Mode=[${THEME_MODE}] Type=[${MATUGEN_TYPE}] Contrast=[${MATUGEN_CONTRAST}]"
-
-    local -a cmd=(matugen --mode "$THEME_MODE")
-    [[ "$MATUGEN_TYPE" != "disable" ]]     && cmd+=(--type "$MATUGEN_TYPE")
-    [[ "$MATUGEN_CONTRAST" != "disable" ]] && cmd+=(--contrast "$MATUGEN_CONTRAST")
-    cmd+=(image "$img")
-
-    "${cmd[@]}" || die "Matugen generation failed"
-
-    command -v gsettings &>/dev/null && \
-        gsettings set org.gnome.desktop.interface color-scheme "prefer-${THEME_MODE}" 2>/dev/null || true
+    log "Generating colors via Matugen"
+    "$MATUGEN_BIN" image "$img"
+    ok "Colors generated"
 }
 
-# --- CLI HANDLER ---
+# ============================================================
+# MAIN
+# ============================================================
+main() {
+    detect_waybar_state
 
-usage() {
-    cat <<'EOF'
-Usage: theme_ctl [COMMAND] [OPTIONS]
+    case "${1:-random}" in
+        random)
+            img=$(get_random_wallpaper)
+            ;;
+        *)
+            img="$1"
+            ;;
+    esac
 
-Commands:
-  set       Update settings and apply changes.
-              --mode <light|dark>
-              --type <scheme-*|disable>
-              --contrast <num|disable>
-              --defaults  Reset all settings to defaults
-              --no-wall   Prevent wallpaper change (e.g., during refresh)
-  random    Cycle to next wallpaper (chronological/natural sort) and apply theme.
-  refresh   Regenerate colors for current wallpaper.
-  get       Show current configuration.
-
-Examples:
-  theme_ctl set --mode dark --type scheme-vibrant
-  theme_ctl set --no-wall --mode light
-  theme_ctl random
-  theme_ctl refresh
-EOF
-}
-
-cmd_get() {
-    if [[ -f "$STATE_FILE" ]]; then
-        cat "$STATE_FILE"
-    else
-        printf '# State file not found\n'
-    fi
-    printf '\n# Public State (%s):\n' "$PUBLIC_STATE_FILE"
-    if [[ -f "$PUBLIC_STATE_FILE" ]]; then
-        cat "$PUBLIC_STATE_FILE"
-    else
-        printf 'N/A\n'
-    fi
-}
-
-cmd_set() {
-    local do_refresh=0 mode_changed=0 same_mode_requested=0 skip_wall=0
-
-    while (( $# > 0 )); do
-        case "$1" in
-            --mode)
-                [[ -n "${2:-}" ]] || die "--mode requires a value"
-                [[ "$2" == "light" || "$2" == "dark" ]] || die "--mode must be 'light' or 'dark'"
-
-                if [[ "$THEME_MODE" != "$2" ]]; then
-                    update_state_key "THEME_MODE" "$2"
-                    mode_changed=1
-                else
-                    same_mode_requested=1
-                fi
-                shift 2
-                ;;
-            --type)
-                [[ -n "${2:-}" ]] || die "--type requires a value"
-                update_state_key "MATUGEN_TYPE" "$2"
-                do_refresh=1
-                shift 2
-                ;;
-            --contrast)
-                [[ -n "${2:-}" ]] || die "--contrast requires a value"
-                update_state_key "MATUGEN_CONTRAST" "$2"
-                do_refresh=1
-                shift 2
-                ;;
-            --defaults)
-                update_state_key "THEME_MODE" "$DEFAULT_MODE"
-                update_state_key "MATUGEN_TYPE" "$DEFAULT_TYPE"
-                update_state_key "MATUGEN_CONTRAST" "$DEFAULT_CONTRAST"
-                mode_changed=1
-                shift
-                ;;
-            --no-wall)
-                skip_wall=1
-                shift
-                ;;
-            --help) usage; exit 0 ;;
-            *) die "Unknown option: $1" ;;
-        esac
-    done
-
-    read_state
-
-    # 1. Action: Wallpaper Shuffle & Swap (Standard use)
-    if (( ! skip_wall )) && (( mode_changed || same_mode_requested )); then
-        move_directories "$THEME_MODE"
-        apply_random_wallpaper
-    else
-        # 2. Action: Directory Swap Only (User changed mode but suppressed wallpaper change)
-        (( mode_changed )) && move_directories "$THEME_MODE"
-
-        # 3. Action: Color Refresh (Settings changed or user forced same-mode refresh)
-        if (( do_refresh || same_mode_requested || mode_changed )); then
-            regenerate_current
-        fi
-    fi
-}
-
-# --- MAIN ---
-
-check_deps
-init_state
-
-case "${1:-}" in
-    set)
-        shift
-        cmd_set "$@"
-        ;;
-    random)
-        move_directories "$THEME_MODE"
-        apply_random_wallpaper
-        ;;
-    refresh|apply)
-        regenerate_current
-        ;;
-    get)
-        cmd_get
-        ;;
-    -h|--help|help)
-        usage
-        ;;
-    "")
-        usage
+    if [[ ! -f "$img" ]]; then
+        err "Wallpaper not found: $img"
         exit 1
-        ;;
-    *)
-        die "Unknown command: $1"
-        ;;
-esac
+    fi
+
+    set_wallpaper "$img"
+    generate_colors "$img"
+    restore_waybar_state
+
+    ok "Theme change complete"
+}
+
+main "$@"

--- a/user_scripts/waybar/waybar_autostart.sh
+++ b/user_scripts/waybar/waybar_autostart.sh
@@ -1,39 +1,87 @@
 #!/usr/bin/env bash
-# -----------------------------------------------------------------------------
-# Description: Robustly restarts Waybar for Hyprland/UWSM sessions.
-#              Uses systemd-run to spawn from a clean user environment,
-#              avoiding XDG_ACTIVATION_TOKEN inheritance issues.
-# Author: dusk
-# -----------------------------------------------------------------------------
-
 set -euo pipefail
 
-# --- Constants ---
+# ------------------------------------------------------
+# Robust Waybar launcher for Hyprland / systemd
+# ------------------------------------------------------
 readonly APP_NAME="waybar"
 readonly TIMEOUT_SEC=5
 
-# --- Terminal-Aware Colors (stderr detection) ---
+# State file written by theme_ctl.sh before Matugen runs.
+# Presence means Waybar was running before the theme change.
+readonly WAYBAR_STATE_FILE="${XDG_RUNTIME_DIR:-/tmp}/waybar_was_running"
+
+# Terminal-aware colors
 if [[ -t 2 ]]; then
     readonly C_RED=$'\033[0;31m'
     readonly C_GREEN=$'\033[0;32m'
     readonly C_BLUE=$'\033[0;34m'
     readonly C_RESET=$'\033[0m'
 else
-    readonly C_RED=''
-    readonly C_GREEN=''
-    readonly C_BLUE=''
-    readonly C_RESET=''
+    readonly C_RED='' C_GREEN='' C_BLUE='' C_RESET=''
 fi
 
-# --- Logging Functions (Strictly to stderr) ---
-# Redirecting logs to stderr keeps stdout clean for piping if needed.
-log_info()    { printf '%s[INFO]%s %s\n' "${C_BLUE}" "${C_RESET}" "$*" >&2; }
-log_success() { printf '%s[OK]%s %s\n' "${C_GREEN}" "${C_RESET}" "$*" >&2; }
-log_err()     { printf '%s[ERROR]%s %s\n' "${C_RED}" "${C_RESET}" "$*" >&2; }
+log_info()    { printf '%s[INFO]%s %s\n'    "${C_BLUE}"  "${C_RESET}" "$*" >&2; }
+log_success() { printf '%s[OK]%s %s\n'      "${C_GREEN}" "${C_RESET}" "$*" >&2; }
+log_err()     { printf '%s[ERROR]%s %s\n'   "${C_RED}"   "${C_RESET}" "$*" >&2; }
 
-# --- Fallback Strategy ---
-# Note: As discovered, this method may not cure the "workspace inheritance" 
-# bug, but it ensures Waybar launches if systemd is broken.
+# ============================================================
+# STATE FILE GUARD
+# When called with "theme-change", respect the state file:
+#   - State file present  → Waybar was running → proceed to launch
+#   - State file absent   → Waybar was hidden  → exit cleanly
+# When called without "theme-change" (e.g. from a keybind or
+# session startup), always proceed regardless.
+# ============================================================
+if [[ "${1:-}" == "theme-change" ]]; then
+    if [[ ! -f "$WAYBAR_STATE_FILE" ]]; then
+        log_info "theme-change mode: Waybar was hidden before theme change, skipping launch."
+        exit 0
+    fi
+    log_info "theme-change mode: Waybar was running before theme change, proceeding."
+    rm -f "$WAYBAR_STATE_FILE"
+    shift
+fi
+
+# ============================================================
+# PREFLIGHT
+# ============================================================
+(( EUID != 0 )) || { log_err "Do NOT run as root"; exit 1; }
+command -v "${APP_NAME}" >/dev/null 2>&1 || { log_err "${APP_NAME} not found"; exit 1; }
+[[ -d ${XDG_RUNTIME_DIR:-} ]]            || { log_err "XDG_RUNTIME_DIR invalid"; exit 1; }
+
+readonly LOCK_FILE="${XDG_RUNTIME_DIR}/${APP_NAME}_manager.lock"
+exec 9>"${LOCK_FILE}"
+flock -n 9 || { log_err "Another instance running"; exit 1; }
+
+# ============================================================
+# MANAGE EXISTING INSTANCES
+# ============================================================
+log_info "Managing ${APP_NAME} instances..."
+
+if pgrep -x "${APP_NAME}" >/dev/null 2>&1; then
+    log_info "Stopping existing instances..."
+    pkill -x "${APP_NAME}" >/dev/null 2>&1 || true
+
+    for (( i=0; i < TIMEOUT_SEC*10; i++ )); do
+        pgrep -x "${APP_NAME}" >/dev/null 2>&1 || break
+        sleep 0.1
+    done
+
+    if pgrep -x "${APP_NAME}" >/dev/null 2>&1; then
+        log_err "Hung process, sending SIGKILL..."
+        pkill -9 -x "${APP_NAME}" >/dev/null 2>&1 || true
+        sleep 0.2
+    fi
+
+    log_success "Cleanup complete."
+else
+    log_info "No running instance found."
+fi
+
+# ============================================================
+# LAUNCH
+# ============================================================
 launch_fallback() {
     log_info "Attempting fallback launch (setsid)..."
     (
@@ -43,55 +91,14 @@ launch_fallback() {
     log_success "${APP_NAME} launched (fallback mode)."
 }
 
-# --- Preflight Checks ---
-(( EUID != 0 )) || { log_err "This script must NOT be run as root."; exit 1; }
-command -v "${APP_NAME}" >/dev/null 2>&1 || { log_err "${APP_NAME} binary not found."; exit 1; }
-[[ -d ${XDG_RUNTIME_DIR:-} ]] || { log_err "XDG_RUNTIME_DIR is not set or invalid."; exit 1; }
-
-readonly LOCK_FILE="${XDG_RUNTIME_DIR}/${APP_NAME}_manager.lock"
-
-# --- Concurrency Lock ---
-# FD 9 is used to hold the lock until the script exits.
-exec 9>"${LOCK_FILE}"
-flock -n 9 || { log_err "Another instance is running. Exiting."; exit 1; }
-
-# --- Process Management ---
-log_info "Managing ${APP_NAME} instances..."
-
-if pgrep -x "${APP_NAME}" >/dev/null 2>&1; then
-    log_info "Stopping existing instances..."
-    pkill -x "${APP_NAME}" >/dev/null 2>&1 || true
-
-    # Poll for termination (Bash C-style loop)
-    for (( i = 0; i < TIMEOUT_SEC * 10; i++ )); do
-        pgrep -x "${APP_NAME}" >/dev/null 2>&1 || break
-        sleep 0.1
-    done
-
-    # Force kill if still resistant
-    if pgrep -x "${APP_NAME}" >/dev/null 2>&1; then
-        log_err "Process hung. Sending SIGKILL..."
-        pkill -9 -x "${APP_NAME}" >/dev/null 2>&1 || true
-        sleep 0.2
-    fi
-    log_success "Cleanup complete."
-else
-    log_info "No running instance found."
-fi
-
-# --- Launch Sequence ---
 log_info "Starting ${APP_NAME}..."
 
 if command -v systemd-run >/dev/null 2>&1; then
-    # Optimization: Use Bash 5.0+ $EPOCHSECONDS instead of forking $(date)
-    # Security: Add $$ (PID) to unit name to prevent collision on rapid re-runs
     unit_name="${APP_NAME}-mgr-${EPOCHSECONDS}-$$"
-
-    # '--' separates options from the command to prevent flag injection
     if systemd-run --user --quiet --unit="${unit_name}" -- "${APP_NAME}" "$@" >/dev/null 2>&1; then
         log_success "${APP_NAME} launched via systemd unit: ${unit_name}"
     else
-        log_err "systemd-run failed; attempting fallback."
+        log_err "systemd-run failed; trying fallback..."
         launch_fallback "$@"
     fi
 else


### PR DESCRIPTION
Waybar was restarting on every theme change even when intentionally hidden.
Fixed by using a state file in XDG_RUNTIME_DIR to track Waybar visibility
across process boundaries, so waybar_autostart.sh respects the hidden state
when triggered by Matugen's post_hook. Also fixes vesktop config path typo.

**Files changed:**
- `user_scripts/theme_matugen/theme_ctl.sh`
- `user_scripts/waybar/waybar_autostart.sh`
- `.config/matugen/config.toml`