### PR TITLE
fix: Preserve Waybar hidden state across theme changes

### DIFF
--- a/.config/matugen/config.toml
+++ b/.config/matugen/config.toml
@@ -51,7 +51,7 @@ output_path = '~/.config/matugen/generated/hyprlock-colors.conf'
 input_path  = '~/.config/matugen/templates/colors.css'
 output_path = '~/.config/matugen/generated/waybar-colors.css'
 post_hook   = '''
-~/user_scripts/waybar/waybar_autostart.sh || true;
+~/user_scripts/waybar/waybar_autostart.sh theme-change || true;
 '''
 
 [templates.swaync]
@@ -122,7 +122,6 @@ input_path  = '~/.config/matugen/templates/zathura-colors'
 output_path = '~/.config/matugen/generated/zathura-colors'
 post_hook   = 'ln -nfs $HOME/.config/matugen/generated/zathura-colors $HOME/.config/zathura/zathurarc'
 
-
 # [templates.starship]
 # input_path = '~/.config/matugen/templates/starship-colors.toml'
 # output_path = '~/.config/matugen/generated/starship-colors.toml'
@@ -156,7 +155,7 @@ ln -nfs $HOME/.config/matugen/generated/obsidian-theme.css $HOME/Documents/pensi
 input_path  = '~/.config/matugen/templates/midnight-discord.css'
 output_path = '~/.config/matugen/generated/midnight-discord.css'
 post_hook   = '''
-mkdir -p $HOME/~/.config/vesktop/themes/;
+mkdir -p $HOME/.config/vesktop/themes/;
 ln -nfs $HOME/.config/matugen/generated/midnight-discord.css $HOME/.config/vesktop/themes/midnight-discord.css
 '''
 

--- a/user_scripts/waybar/waybar_autostart.sh
+++ b/user_scripts/waybar/waybar_autostart.sh
@@ -1,39 +1,87 @@
 #!/usr/bin/env bash
-# -----------------------------------------------------------------------------
-# Description: Robustly restarts Waybar for Hyprland/UWSM sessions.
-#              Uses systemd-run to spawn from a clean user environment,
-#              avoiding XDG_ACTIVATION_TOKEN inheritance issues.
-# Author: dusk
-# -----------------------------------------------------------------------------
-
 set -euo pipefail
 
-# --- Constants ---
+# ------------------------------------------------------
+# Robust Waybar launcher for Hyprland / systemd
+# ------------------------------------------------------
 readonly APP_NAME="waybar"
 readonly TIMEOUT_SEC=5
 
-# --- Terminal-Aware Colors (stderr detection) ---
+# State file written by theme_ctl.sh before Matugen runs.
+# Presence means Waybar was running before the theme change.
+readonly WAYBAR_STATE_FILE="${XDG_RUNTIME_DIR:-/tmp}/waybar_was_running"
+
+# Terminal-aware colors
 if [[ -t 2 ]]; then
     readonly C_RED=$'\033[0;31m'
     readonly C_GREEN=$'\033[0;32m'
     readonly C_BLUE=$'\033[0;34m'
     readonly C_RESET=$'\033[0m'
 else
-    readonly C_RED=''
-    readonly C_GREEN=''
-    readonly C_BLUE=''
-    readonly C_RESET=''
+    readonly C_RED='' C_GREEN='' C_BLUE='' C_RESET=''
 fi
 
-# --- Logging Functions (Strictly to stderr) ---
-# Redirecting logs to stderr keeps stdout clean for piping if needed.
-log_info()    { printf '%s[INFO]%s %s\n' "${C_BLUE}" "${C_RESET}" "$*" >&2; }
-log_success() { printf '%s[OK]%s %s\n' "${C_GREEN}" "${C_RESET}" "$*" >&2; }
-log_err()     { printf '%s[ERROR]%s %s\n' "${C_RED}" "${C_RESET}" "$*" >&2; }
+log_info()    { printf '%s[INFO]%s %s\n'    "${C_BLUE}"  "${C_RESET}" "$*" >&2; }
+log_success() { printf '%s[OK]%s %s\n'      "${C_GREEN}" "${C_RESET}" "$*" >&2; }
+log_err()     { printf '%s[ERROR]%s %s\n'   "${C_RED}"   "${C_RESET}" "$*" >&2; }
 
-# --- Fallback Strategy ---
-# Note: As discovered, this method may not cure the "workspace inheritance" 
-# bug, but it ensures Waybar launches if systemd is broken.
+# ============================================================
+# STATE FILE GUARD
+# When called with "theme-change", respect the state file:
+#   - State file present  → Waybar was running → proceed to launch
+#   - State file absent   → Waybar was hidden  → exit cleanly
+# When called without "theme-change" (e.g. from a keybind or
+# session startup), always proceed regardless.
+# ============================================================
+if [[ "${1:-}" == "theme-change" ]]; then
+    if [[ ! -f "$WAYBAR_STATE_FILE" ]]; then
+        log_info "theme-change mode: Waybar was hidden before theme change, skipping launch."
+        exit 0
+    fi
+    log_info "theme-change mode: Waybar was running before theme change, proceeding."
+    rm -f "$WAYBAR_STATE_FILE"
+    shift
+fi
+
+# ============================================================
+# PREFLIGHT
+# ============================================================
+(( EUID != 0 )) || { log_err "Do NOT run as root"; exit 1; }
+command -v "${APP_NAME}" >/dev/null 2>&1 || { log_err "${APP_NAME} not found"; exit 1; }
+[[ -d ${XDG_RUNTIME_DIR:-} ]]            || { log_err "XDG_RUNTIME_DIR invalid"; exit 1; }
+
+readonly LOCK_FILE="${XDG_RUNTIME_DIR}/${APP_NAME}_manager.lock"
+exec 9>"${LOCK_FILE}"
+flock -n 9 || { log_err "Another instance running"; exit 1; }
+
+# ============================================================
+# MANAGE EXISTING INSTANCES
+# ============================================================
+log_info "Managing ${APP_NAME} instances..."
+
+if pgrep -x "${APP_NAME}" >/dev/null 2>&1; then
+    log_info "Stopping existing instances..."
+    pkill -x "${APP_NAME}" >/dev/null 2>&1 || true
+
+    for (( i=0; i < TIMEOUT_SEC*10; i++ )); do
+        pgrep -x "${APP_NAME}" >/dev/null 2>&1 || break
+        sleep 0.1
+    done
+
+    if pgrep -x "${APP_NAME}" >/dev/null 2>&1; then
+        log_err "Hung process, sending SIGKILL..."
+        pkill -9 -x "${APP_NAME}" >/dev/null 2>&1 || true
+        sleep 0.2
+    fi
+
+    log_success "Cleanup complete."
+else
+    log_info "No running instance found."
+fi
+
+# ============================================================
+# LAUNCH
+# ============================================================
 launch_fallback() {
     log_info "Attempting fallback launch (setsid)..."
     (
@@ -43,55 +91,14 @@ launch_fallback() {
     log_success "${APP_NAME} launched (fallback mode)."
 }
 
-# --- Preflight Checks ---
-(( EUID != 0 )) || { log_err "This script must NOT be run as root."; exit 1; }
-command -v "${APP_NAME}" >/dev/null 2>&1 || { log_err "${APP_NAME} binary not found."; exit 1; }
-[[ -d ${XDG_RUNTIME_DIR:-} ]] || { log_err "XDG_RUNTIME_DIR is not set or invalid."; exit 1; }
-
-readonly LOCK_FILE="${XDG_RUNTIME_DIR}/${APP_NAME}_manager.lock"
-
-# --- Concurrency Lock ---
-# FD 9 is used to hold the lock until the script exits.
-exec 9>"${LOCK_FILE}"
-flock -n 9 || { log_err "Another instance is running. Exiting."; exit 1; }
-
-# --- Process Management ---
-log_info "Managing ${APP_NAME} instances..."
-
-if pgrep -x "${APP_NAME}" >/dev/null 2>&1; then
-    log_info "Stopping existing instances..."
-    pkill -x "${APP_NAME}" >/dev/null 2>&1 || true
-
-    # Poll for termination (Bash C-style loop)
-    for (( i = 0; i < TIMEOUT_SEC * 10; i++ )); do
-        pgrep -x "${APP_NAME}" >/dev/null 2>&1 || break
-        sleep 0.1
-    done
-
-    # Force kill if still resistant
-    if pgrep -x "${APP_NAME}" >/dev/null 2>&1; then
-        log_err "Process hung. Sending SIGKILL..."
-        pkill -9 -x "${APP_NAME}" >/dev/null 2>&1 || true
-        sleep 0.2
-    fi
-    log_success "Cleanup complete."
-else
-    log_info "No running instance found."
-fi
-
-# --- Launch Sequence ---
 log_info "Starting ${APP_NAME}..."
 
 if command -v systemd-run >/dev/null 2>&1; then
-    # Optimization: Use Bash 5.0+ $EPOCHSECONDS instead of forking $(date)
-    # Security: Add $$ (PID) to unit name to prevent collision on rapid re-runs
     unit_name="${APP_NAME}-mgr-${EPOCHSECONDS}-$$"
-
-    # '--' separates options from the command to prevent flag injection
     if systemd-run --user --quiet --unit="${unit_name}" -- "${APP_NAME}" "$@" >/dev/null 2>&1; then
         log_success "${APP_NAME} launched via systemd unit: ${unit_name}"
     else
-        log_err "systemd-run failed; attempting fallback."
+        log_err "systemd-run failed; trying fallback..."
         launch_fallback "$@"
     fi
 else


### PR DESCRIPTION
Waybar was unconditionally restarted on every theme change even when 
intentionally hidden by the user. This happened because Matugen's waybar 
post_hook ran waybar_autostart.sh in a separate process, completely bypassing 
any state detection in theme_ctl.sh.

**Changes:**
- `theme_ctl.sh` — writes a state file to `XDG_RUNTIME_DIR` before Matugen 
  runs if Waybar was running, skips it if hidden. Added `detect_waybar_state` 
  and `restore_waybar_state` functions, called in `apply_random_wallpaper` 
  and `regenerate_current`.
- `waybar_autostart.sh` — added `theme-change` argument guard. If called with 
  this arg and state file is absent, exits without launching Waybar.
- `config.toml` — passes `theme-change` arg in waybar post_hook. Also fixes 
  vesktop post_hook path typo (`$HOME/~/` → `$HOME/`).