### PR TITLE
Change clock format to 12-hour in waybar 02-translucent

### DIFF
--- a/.config/waybar/02_horizontal_block_translucent/config.jsonc
+++ b/.config/waybar/02_horizontal_block_translucent/config.jsonc
@@ -46,8 +46,8 @@
   },
 
   "clock": {
-    "format": "󰥔 {:%H:%M}",
-    //"format": "󰥔 {:%I:%M}", //24 hour format for teh clock.
+    "format": "󰥔 {:%I:%M}",
+    //"format": "󰥔 {:%H:%M}", //24 hour format for the clock.
     "format-alt": "󰃭 {:%A, %B %d}",
     "tooltip-format": "<tt><span size='12pt' font='JetBrainsMono Nerd Font'>{calendar}</span></tt>",
     "on-click-right": "uwsm-app -- gnome-clocks",


### PR DESCRIPTION
It seems that the default for the waybar configs is 12 hour format. This one just happened to be flipped around.