### PR TITLE
update matugen theming of spicetify

### DIFF
--- a/.config/matugen/config.toml
+++ b/.config/matugen/config.toml
@@ -229,8 +229,8 @@ post_hook   = '''
 # input_path  = '~/.config/matugen/templates/spotify-colors.ini'
 # output_path = '~/.config/matugen/generated/spotify-colors.ini'
 # post_hook   = '''
-# if command -v spicetify >/dev/null 2>&1 && [ -d "$HOME/.config/spicetify/Themes/Comfy" ]; then
-#     ln -nfs "$HOME/.config/matugen/generated/spotify-colors.ini" "$HOME/.config/spicetify/Themes/Comfy/color.ini"
+# if command -v spicetify >/dev/null 2>&1 && [ -d "$HOME/.config/spicetify/Themes/wal" ]; then
+#     ln -nfs "$HOME/.config/matugen/generated/spotify-colors.ini" "$HOME/.config/spicetify/Themes/wal/color.ini"
 #     spicetify apply -n || :
 #     hyprctl dispatch sendshortcut "CTRL SHIFT, R, class:^(spotify)$" || :
 # fi

--- a/.config/matugen/templates/spotify-colors.ini
+++ b/.config/matugen/templates/spotify-colors.ini
@@ -1,27 +1,27 @@
 #  ┏┓┏┓┏┓┏┳┓┳┏┓┓┏  ┳┳┓┏┓┏┳┓┳┳┏┓┏┓┳┓
 #  ┗┓┃┃┃┃ ┃ ┃┣ ┗┫━━┃┃┃┣┫ ┃ ┃┃┃┓┣ ┃┃
 #  ┗┛┣┛┗┛ ┻ ┻┻ ┗┛  ┛ ┗┛┗ ┻ ┗┛┗┛┗┛┛┗
-#                                  
+#
 
 
-[Comfy]
+[wal]
 text               = {{ colors.on_surface.default.hex_stripped }}
 subtext            = {{ colors.on_surface_variant.default.hex_stripped }}
 main               = {{ colors.surface.default.hex_stripped }}
-main-elevated      = {{ colors.surface_bright.default.hex_stripped }}
+main-elevated      = {{ colors.surface.default.hex_stripped }}
 main-transition    = {{ colors.surface_container_lowest.default.hex_stripped }}
 highlight          = {{ colors.surface_container_low.default.hex_stripped }}
-highlight-elevated = {{ colors.surface_container_highest.default.hex_stripped }}
+highlight-elevated = {{ colors.surface_container_low.default.hex_stripped }}
 sidebar            = {{ colors.surface.default.hex_stripped }}
-player             = {{ colors.scrim.default.hex_stripped }}
-card               = {{ colors.scrim.default.hex_stripped }}
-shadow             = {{ colors.scrim.default.hex_stripped }}
+player             = {{ colors.surface.default.hex_stripped }}
+card               = {{ colors.surface_container_low.default.hex_stripped }}
+shadow             = {{ colors.surface.default.hex_stripped }}
 selected-row       = {{ colors.on_surface.default.hex_stripped }}
 button             = {{ colors.primary.default.hex_stripped }}
 button-active      = {{ colors.primary_fixed.default.hex_stripped }}
 button-disabled    = {{ colors.primary_fixed_dim.default.hex_stripped }}
-tab-active         = {{ colors.surface.default.hex_stripped }}
-notification       = {{ colors.tertiary.default.hex_stripped }}
+tab-active         = {{ colors.surface_container_low.default.hex_stripped }}
+notification       = {{ colors.surface.default.hex_stripped }}
 notification-error = {{ colors.error.default.hex_stripped }}
 misc               = {{ colors.scrim.default.hex_stripped }}
 play-button        = {{ colors.secondary.default.hex_stripped }}


### PR DESCRIPTION
# Simplify the spicetify theming rather than using Comfy and making the matugen theme a bit modern
<img width="1482" height="664" alt="image" src="https://github.com/user-attachments/assets/e743896b-2372-4501-a009-e44e6a89f350" />
<img width="1484" height="668" alt="image" src="https://github.com/user-attachments/assets/cd7ad81a-16a6-41ed-9659-072d65645bae" />

```bash
#!/bin/sh

set -e

# Get Spicetify base directory
spice_dir="$(dirname "$(spicetify -c)")"
theme_dir="${spice_dir}/Themes"

# Create wal theme directory
mkdir -p "${theme_dir}/wal"

# Apply theme
echo "Applying wal theme..."
spicetify config current_theme wal color_scheme wal
spicetify config inject_css 1
spicetify apply

echo "Wal theme created"
```
## Implementation:
- Creates the wal theme folder in your Spicetify Themes directory
- Sets Spicetify’s current theme to wal
- Configures CSS injection and applies the theme
> [!Note]
> It will show `error  Cannot open file $HOME/.config/spicetify/Themes/wal/color.ini`, cause the matugen still havent generated a theme for spotify. Just need to refresh the wallpaper.
> 
> Spotify will automatically change the theme realtime everytime a new theme is generated.
