### PR TITLE
feat: WireGuard Control Center integration

### DIFF
--- a/user_scripts/dusky_system/control_center/dusky_config.yaml
+++ b/user_scripts/dusky_system/control_center/dusky_config.yaml
@@ -803,6 +803,111 @@ pages:
         type: exec
         command: kitty --class 325_hosts_files_block.sh --hold sh -c "$HOME/user_scripts/arch_setup_scripts/scripts/325_hosts_files_block.sh"
         terminal: false
+- id: wireguard
+  title: WireGuard
+  icon: network-vpn-symbolic
+  layout:
+  - type: warning_banner
+    properties:
+      title: "Privilege Requirements"
+      message: "Toggling tunnels uses sudo (wg-quick). Run the setup script once to configure NOPASSWD rules and fix /etc/wireguard permissions."
+  - type: section
+    properties:
+      title: VPN Tunnels
+      description: "Scans /etc/wireguard/ and immediate subdirectories for *.conf files"
+    items:
+      - type: file_generator
+        properties:
+          path: /etc/wireguard
+          glob: "*.conf"
+          recursive: true
+        item_template:
+          type: expander
+          properties:
+            title: "{name_pretty}"
+            description: "{relpath}"
+            icon: network-vpn-symbolic
+          items:
+            - type: toggle
+              properties:
+                title: "Enable Tunnel"
+                description: "Bring tunnel up or down"
+                icon: network-vpn-symbolic
+                state_command: "[ -d /sys/class/net/{name} ] && echo yes || echo no"
+                interval: 5
+              on_toggle:
+                enabled:
+                  type: exec
+                  command: "sudo wg-quick up {path}"
+                  terminal: false
+                disabled:
+                  type: exec
+                  command: "sudo wg-quick down {path}"
+                  terminal: false
+            - type: button
+              properties:
+                title: "Edit Config"
+                description: "{path}"
+                icon: document-edit-symbolic
+                button_text: "Edit"
+              on_press:
+                type: exec
+                command: "kitty --class dusky_wg_edit --hold sh -c 'sudo $EDITOR {path}'"
+                terminal: false
+            - type: button
+              properties:
+                title: "Live Status"
+                description: "Open wg show {name} in terminal"
+                icon: utilities-terminal-symbolic
+                button_text: "Show"
+              on_press:
+                type: exec
+                command: "kitty --class dusky_wg_status --hold sh -c 'sudo wg show {name} 2>/dev/null || echo Inactive; echo; printf \"Press Enter to close...\"; read'"
+                terminal: false
+            - type: button
+              properties:
+                title: "Delete Tunnel"
+                description: "Permanently remove {relpath}"
+                icon: list-remove-symbolic
+                button_text: "Delete"
+              on_press:
+                type: exec
+                command: "kitty --class dusky_wg_delete --hold sh -c 'printf \"\\e[1;31mDelete {relpath}?\\e[0m [y/N] \"; read c; case $c in [Yy]) sudo rm {path} && echo \"Deleted {relpath}.\" || echo \"Failed.\";; *) echo \"Aborted.\";; esac; echo; printf \"Press Enter to close...\"; read'"
+                terminal: false
+  - type: section
+    properties:
+      title: Management
+    items:
+      - type: button
+        properties:
+          title: "New Tunnel Config"
+          description: "Create a new wg-quick config (auto chown root:root 600)"
+          icon: list-add-symbolic
+          button_text: "New"
+        on_press:
+          type: exec
+          command: "kitty --class dusky_wg_new --hold sh -c '$HOME/user_scripts/networking/dusky_wireguard_new.sh'"
+          terminal: false
+      - type: button
+        properties:
+          title: "All Tunnels Status"
+          description: "wg show all"
+          icon: network-vpn-symbolic
+          button_text: "Show"
+        on_press:
+          type: exec
+          command: "kitty --class dusky_wg_status --hold sh -c 'sudo wg show all; echo; echo \"Press Enter to close...\"; read'"
+          terminal: false
+      - type: button
+        properties:
+          title: "Setup Permissions"
+          description: "Run once: sets /etc/wireguard to 750 root:wheel and adds sudoers rules"
+          icon: security-medium-symbolic
+          button_text: "Setup"
+        on_press:
+          type: exec
+          command: "kitty --class dusky_wg_setup --hold sh -c '$HOME/user_scripts/networking/dusky_wireguard_setup.sh'"
+          terminal: false
 - id: hardware
   title: Hardware
   icon: input-keyboard-symbolic

--- a/user_scripts/dusky_system/control_center/dusky_control_center.py
+++ b/user_scripts/dusky_system/control_center/dusky_control_center.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import gc
 import logging
+import subprocess
 import sys
 import threading
 import traceback
@@ -146,6 +147,7 @@ class ItemType(StrEnum):
     GRID_CARD = "grid_card"
     EXPANDER = "expander"
     DIRECTORY_GENERATOR = "directory_generator"
+    FILE_GENERATOR = "file_generator"
     ASYNC_SELECTOR = "async_selector"
 
 class SectionType(StrEnum):
@@ -1152,6 +1154,11 @@ class DuskyControlCenter(Adw.Application):
                 yield from self._iter_item_hits(gen_item, query, breadcrumb, page_idx, nav_path)
             return
 
+        if item_type == ItemType.FILE_GENERATOR:
+            for gen_item in self._process_file_generator(item):
+                yield from self._iter_item_hits(gen_item, query, breadcrumb, page_idx, nav_path)
+            return
+
         title = str(props.get("title", "")).strip()
         desc = str(props.get("description", "")).strip()
 
@@ -1463,6 +1470,9 @@ class DuskyControlCenter(Adw.Application):
             if item.get("type") == ItemType.DIRECTORY_GENERATOR:
                 for gen_item in self._process_directory_generator(item):
                     append_grid_item(gen_item)
+            elif item.get("type") == ItemType.FILE_GENERATOR:
+                for gen_item in self._process_file_generator(item):
+                    append_grid_item(gen_item)
             else:
                 append_grid_item(item)
 
@@ -1486,6 +1496,9 @@ class DuskyControlCenter(Adw.Application):
         for item in section.get("items", []):
             if item.get("type") == ItemType.DIRECTORY_GENERATOR:
                 for gen_item in self._process_directory_generator(item):
+                    group.add(self._build_item_row(gen_item, ctx))
+            elif item.get("type") == ItemType.FILE_GENERATOR:
+                for gen_item in self._process_file_generator(item):
                     group.add(self._build_item_row(gen_item, ctx))
             else:
                 group.add(self._build_item_row(item, ctx))
@@ -1542,6 +1555,82 @@ class DuskyControlCenter(Adw.Application):
         frozen = tuple(generated)
         self._directory_generator_cache[cache_key] = frozen
         yield from frozen
+
+    def _process_file_generator(self, config: ConfigItem) -> Iterator[ConfigItem]:
+        """Generate items from files in a directory, with optional glob filtering.
+
+        Properties:
+          path      – base directory to scan
+          glob      – glob pattern (default "*.conf")
+          recursive – if true, also scans immediate subdirectories (default false)
+
+        Template variables:
+          {name}        – filename stem (e.g. "wg0", "us-nyc-wg-506")
+          {filename}    – filename with extension (e.g. "wg0.conf")
+          {path}        – absolute path (e.g. "/etc/wireguard/wg0.conf")
+          {name_pretty} – human-readable stem (e.g. "Wg0", "Us Nyc Wg 506")
+          {relpath}     – path relative to base (e.g. "wg0.conf", "mullvad/us-nyc-wg-506.conf")
+          {subdir}      – parent dir name for subdir files, empty for top-level
+
+        Intentionally not cached so newly added configs appear without Ctrl+R.
+        Symlinks are included — wg-quick resolves them as root; we only need the name.
+        """
+        props = config.get("properties", {})
+        if not isinstance(props, dict):
+            return
+
+        template = config.get("item_template")
+        if not isinstance(template, dict):
+            return
+
+        path_str = props.get("path", "")
+        glob_pattern = props.get("glob", "*.conf")
+        recursive = bool(props.get("recursive", False))
+
+        if not isinstance(path_str, str) or not path_str:
+            return
+
+        base_path = Path(path_str).expanduser()
+
+        def _iter_files() -> Iterator[Path]:
+            try:
+                for p in base_path.glob(glob_pattern):
+                    if p.is_file() or p.is_symlink():
+                        yield p
+            except (OSError, PermissionError):
+                return
+            if recursive:
+                try:
+                    for subdir in sorted(base_path.iterdir()):
+                        if not subdir.is_dir() or subdir.is_symlink():
+                            continue
+                        try:
+                            for p in subdir.glob(glob_pattern):
+                                if p.is_file() or p.is_symlink():
+                                    yield p
+                        except (OSError, PermissionError):
+                            continue
+                except (OSError, PermissionError):
+                    return
+
+        files = sorted(_iter_files(), key=lambda p: (p.parent != base_path, p.name.casefold()))
+
+        for filepath in files:
+            stem = filepath.stem
+            is_subdir = filepath.parent != base_path
+            subdir_name = filepath.parent.name if is_subdir else ""
+            relpath = f"{subdir_name}/{filepath.name}" if is_subdir else filepath.name
+            variables = {
+                "name": stem,
+                "filename": filepath.name,
+                "path": str(filepath),
+                "name_pretty": stem.replace("_", " ").replace("-", " ").title(),
+                "relpath": relpath,
+                "subdir": subdir_name,
+            }
+            gen_item = self._inject_variables(template, variables)
+            if isinstance(gen_item, dict):
+                yield gen_item
 
     def _inject_variables(self, item: Any, vars: dict[str, str]) -> Any:
         """Recursively replace variables in strings."""

--- a/user_scripts/networking/dusky_wireguard_new.sh
+++ b/user_scripts/networking/dusky_wireguard_new.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# dusky_wireguard_new.sh
+# ==============================================================================
+# Interactive wizard to create a new wg-quick tunnel config.
+# The resulting file is written as root:root 600 — private keys never land
+# on disk with loose permissions.
+#
+# Usage: run from the Dusky Control Center WireGuard page.
+# ==============================================================================
+set -euo pipefail
+
+readonly CLR_GRN=$'\e[1;32m'
+readonly CLR_YLW=$'\e[1;33m'
+readonly CLR_RED=$'\e[1;31m'
+readonly CLR_BLU=$'\e[1;34m'
+readonly CLR_CYN=$'\e[1;36m'
+readonly CLR_RST=$'\e[0m'
+readonly CLR_DIM=$'\e[2m'
+
+ok()     { printf '%s[OK]%s    %s\n' "$CLR_GRN" "$CLR_RST" "$1"; }
+info()   { printf '%s[INFO]%s  %s\n' "$CLR_BLU" "$CLR_RST" "$1"; }
+warn()   { printf '%s[WARN]%s  %s\n' "$CLR_YLW" "$CLR_RST" "$1"; }
+err()    { printf '%s[ERR]%s   %s\n' "$CLR_RED" "$CLR_RST" "$1" >&2; }
+prompt() { printf '%s%s%s ' "$CLR_CYN" "$1" "$CLR_RST"; }
+header() { printf '\n%s══ %s ══%s\n\n' "$CLR_BLU" "$1" "$CLR_RST"; }
+
+# ── Dependency check ──────────────────────────────────────────────────────────
+if ! command -v wg &>/dev/null; then
+    err "wireguard-tools not installed. Run: sudo pacman -S wireguard-tools"
+    exit 1
+fi
+
+header "Dusky WireGuard — New Tunnel Wizard"
+info "Config is written directly to /etc/wireguard/<name>.conf as root:root 600."
+info "The private key never touches a user-writable path."
+echo
+
+# ── Interface name ─────────────────────────────────────────────────────────────
+while true; do
+    prompt "Interface name (e.g. wg0, vpn1, work):"
+    read -r IFACE
+    IFACE="${IFACE//[^a-zA-Z0-9_-]/}"      # strip unsafe chars
+    if [[ -z "$IFACE" ]]; then
+        warn "Name cannot be empty"; continue
+    fi
+    if [[ -f "/etc/wireguard/${IFACE}.conf" ]]; then
+        warn "/etc/wireguard/${IFACE}.conf already exists — choose a different name"
+        continue
+    fi
+    break
+done
+
+# ── Key generation ─────────────────────────────────────────────────────────────
+info "Generating keypair ..."
+PRIVATE_KEY="$(wg genkey)"
+PUBLIC_KEY="$(printf '%s' "$PRIVATE_KEY" | wg pubkey)"
+ok "Keys generated (private key stays in memory only)"
+printf '  %sPublic key:%s  %s\n' "$CLR_DIM" "$CLR_RST" "$PUBLIC_KEY"
+echo
+
+# ── Interface address ──────────────────────────────────────────────────────────
+prompt "Tunnel IP address (e.g. 10.0.0.2/24):"
+read -r IFACE_ADDR
+
+# ── DNS (optional) ─────────────────────────────────────────────────────────────
+prompt "DNS server (leave blank to skip, e.g. 1.1.1.1):"
+read -r DNS
+
+# ── Peer configuration ─────────────────────────────────────────────────────────
+header "Peer (Server) Configuration"
+prompt "Peer public key:"
+read -r PEER_PUBKEY
+
+prompt "Peer endpoint (host:port, e.g. vpn.example.com:51820):"
+read -r PEER_ENDPOINT
+
+prompt "Allowed IPs (e.g. 0.0.0.0/0 for full-tunnel, or 10.0.0.0/24):"
+read -r ALLOWED_IPS
+ALLOWED_IPS="${ALLOWED_IPS:-0.0.0.0/0, ::/0}"
+
+prompt "Persistent keepalive in seconds (leave blank to skip, e.g. 25):"
+read -r KEEPALIVE
+
+# ── Build config content ───────────────────────────────────────────────────────
+CONFIG_CONTENT="[Interface]
+PrivateKey = ${PRIVATE_KEY}
+Address = ${IFACE_ADDR}"
+
+if [[ -n "$DNS" ]]; then
+    CONFIG_CONTENT+="
+DNS = ${DNS}"
+fi
+
+CONFIG_CONTENT+="
+
+[Peer]
+PublicKey = ${PEER_PUBKEY}
+Endpoint = ${PEER_ENDPOINT}
+AllowedIPs = ${ALLOWED_IPS}"
+
+if [[ -n "$KEEPALIVE" && "$KEEPALIVE" =~ ^[0-9]+$ ]]; then
+    CONFIG_CONTENT+="
+PersistentKeepalive = ${KEEPALIVE}"
+fi
+
+# ── Review ─────────────────────────────────────────────────────────────────────
+header "Review"
+printf '%s%s%s\n' "$CLR_DIM" "$CONFIG_CONTENT" "$CLR_RST"
+echo
+prompt "Write to /etc/wireguard/${IFACE}.conf? [y/N]:"
+read -r CONFIRM
+if [[ ! "$CONFIRM" =~ ^[Yy]$ ]]; then
+    warn "Aborted — no file written"
+    exit 0
+fi
+
+# ── Write as root ─────────────────────────────────────────────────────────────
+DEST="/etc/wireguard/${IFACE}.conf"
+printf '%s\n' "$CONFIG_CONTENT" | sudo tee "$DEST" > /dev/null
+sudo chown root:root "$DEST"
+sudo chmod 600 "$DEST"
+
+ok "Config written: $DEST (root:root 600)"
+printf '  %sPublic key:%s  %s\n' "$CLR_DIM" "$CLR_RST" "$PUBLIC_KEY"
+echo
+info "Reload the Dusky Control Center (Ctrl+R) to see the new tunnel."
+echo
+printf 'Press Enter to close...'
+read -r

--- a/user_scripts/networking/dusky_wireguard_setup.sh
+++ b/user_scripts/networking/dusky_wireguard_setup.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# dusky_wireguard_setup.sh
+# ==============================================================================
+# Run once to configure the system for the Dusky WireGuard CC integration:
+#   0. Installs wireguard-tools via pacman if not present
+#   1. Creates /etc/wireguard/ if absent
+#   2. Sets ownership/permissions: root:wheel 750 (wheel can list, not read keys)
+#   3. Installs /etc/sudoers.d/dusky-wireguard granting NOPASSWD for wg-quick
+# ==============================================================================
+set -euo pipefail
+
+readonly CLR_GRN=$'\e[1;32m'
+readonly CLR_YLW=$'\e[1;33m'
+readonly CLR_RED=$'\e[1;31m'
+readonly CLR_BLU=$'\e[1;34m'
+readonly CLR_RST=$'\e[0m'
+
+ok()   { printf '%s[OK]%s    %s\n' "$CLR_GRN" "$CLR_RST" "$1"; }
+info() { printf '%s[INFO]%s  %s\n' "$CLR_BLU" "$CLR_RST" "$1"; }
+warn() { printf '%s[WARN]%s  %s\n' "$CLR_YLW" "$CLR_RST" "$1"; }
+err()  { printf '%s[ERR]%s   %s\n' "$CLR_RED" "$CLR_RST" "$1" >&2; }
+
+CURRENT_USER="${SUDO_USER:-$USER}"
+
+# ── 0. Ensure wireguard-tools is installed ────────────────────────────────────
+if command -v wg &>/dev/null; then
+    ok "wireguard-tools already installed ($(wg --version 2>/dev/null || echo wg found))"
+else
+    info "wireguard-tools not found — installing via pacman ..."
+    if sudo pacman -S --noconfirm wireguard-tools; then
+        ok "wireguard-tools installed"
+    else
+        err "Failed to install wireguard-tools — aborting"
+        exit 1
+    fi
+fi
+
+# ── 1. Ensure /etc/wireguard exists ──────────────────────────────────────────
+if [[ ! -d /etc/wireguard ]]; then
+    info "Creating /etc/wireguard ..."
+    sudo mkdir -p /etc/wireguard
+    ok "Directory created"
+else
+    info "/etc/wireguard already exists"
+fi
+
+# ── 2. Set permissions: root:wheel 750 ───────────────────────────────────────
+# 750 = root can rwx, wheel can r-x (list + traverse), others nothing.
+# Individual .conf files stay at 600 root:root — private keys never world-readable.
+info "Setting /etc/wireguard ownership to root:wheel, mode 750 ..."
+sudo chown root:wheel /etc/wireguard
+sudo chmod 750 /etc/wireguard
+ok "Directory permissions set (root:wheel 750)"
+
+# ── 3. Lock down any existing configs ────────────────────────────────────────
+shopt -s nullglob
+confs=(/etc/wireguard/*.conf)
+if (( ${#confs[@]} > 0 )); then
+    info "Securing existing configs (root:root 600) ..."
+    for conf in "${confs[@]}"; do
+        sudo chown root:root "$conf"
+        sudo chmod 600 "$conf"
+        ok "Secured: $conf"
+    done
+else
+    info "No existing configs to secure"
+fi
+
+# ── 4. Install sudoers rules ──────────────────────────────────────────────────
+SUDOERS_FILE="/etc/sudoers.d/dusky-wireguard"
+info "Installing sudoers rules to $SUDOERS_FILE ..."
+
+sudo tee "$SUDOERS_FILE" > /dev/null <<EOF
+# Dusky WireGuard CC integration — allow wheel members to manage tunnels
+# systemd-style (wg-quick@<name>)
+%wheel ALL=(ALL) NOPASSWD: /usr/bin/systemctl start wg-quick@*
+%wheel ALL=(ALL) NOPASSWD: /usr/bin/systemctl stop wg-quick@*
+%wheel ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart wg-quick@*
+# direct wg-quick (also matches path-based: wg-quick up /etc/wireguard/subdir/name.conf)
+%wheel ALL=(ALL) NOPASSWD: /usr/bin/wg-quick up *
+%wheel ALL=(ALL) NOPASSWD: /usr/bin/wg-quick down *
+# wg show (live status + diagnostics)
+%wheel ALL=(ALL) NOPASSWD: /usr/bin/wg show
+%wheel ALL=(ALL) NOPASSWD: /usr/bin/wg show *
+EOF
+
+sudo chmod 440 "$SUDOERS_FILE"
+
+# Validate — visudo -c will catch syntax errors before they lock you out
+if sudo visudo -c -f "$SUDOERS_FILE" &>/dev/null; then
+    ok "Sudoers rules installed and validated"
+else
+    err "Sudoers syntax check failed — removing $SUDOERS_FILE to prevent lockout"
+    sudo rm -f "$SUDOERS_FILE"
+    exit 1
+fi
+
+# ── 5. Summary ───────────────────────────────────────────────────────────────
+echo
+printf '%s══ Setup Complete ══%s\n' "$CLR_GRN" "$CLR_RST"
+echo "  /etc/wireguard/       → root:wheel 750"
+echo "  *.conf files          → root:root  600"
+echo "  $SUDOERS_FILE → NOPASSWD for wg-quick, wg show"
+echo
+info "You can now add tunnels via the Dusky Control Center → WireGuard"
+echo
+printf 'Press Enter to close...'
+read -r


### PR DESCRIPTION
## Summary

- Adds a **WireGuard page** to Dusky Control Center with dynamic tunnel discovery via the new `file_generator` item type — scans `/etc/wireguard/` for `*.conf` files and generates a card per tunnel with enable/disable toggle, edit, live status, and delete actions
- Implements **`file_generator` item type** in `dusky_control_center.py` — scans a directory for files matching a glob, instantiates CC rows from a template with `{name}`, `{path}`, `{relpath}`, `{name_pretty}` substitutions; reusable for any future file-backed resource
- Adds **`dusky_wireguard_new.sh`** — interactive wizard to create a `wg-quick` config (auto `chown root:root 600`)
- Adds **`dusky_wireguard_setup.sh`** — one-shot script that sets `/etc/wireguard` to `750 root:wheel` and writes NOPASSWD sudoers rules so `wg-quick` works without a password prompt

## Tested:

- [x] WireGuard page loads without error
- [x] `.conf` file → card appears with correct name and path
- [x] Toggle enable → `wg-quick up` runs, interface visible in `ip link`
- [x] Toggle disable → `wg-quick down` runs, interface removed
- [x] Edit button opens config in `$EDITOR` inside kitty
- [x] Show button opens `wg show <name>` in kitty
- [x] Delete prompts confirmation, removes file on `y`
- [x] `dusky_wireguard_new.sh` creates a valid config at the specified path
- [x] `dusky_wireguard_setup.sh` updates permissions and sudoers

