### PR TITLE
Fix typo in battery full notification message

### DIFF
--- a/user_scripts/battery/notify/battery_notify.sh
+++ b/user_scripts/battery/notify/battery_notify.sh
@@ -301,7 +301,7 @@ process_battery_event() {
     if [[ "$state" == "Charging" ]] && ((percentage >= BATTERY_FULL_THRESHOLD)); then
         if ((now - STATE_LAST_FULL_NOTIFY >= REPEAT_FULL_MIN * 60)); then
             fn_notify "normal" "🔋 Battery Full" \
-                "Level: $percentage% - Congratulatons!" \
+                "Level: $percentage% - Congratulations!" \
                 "battery-full-charged-symbolic" ""
             STATE_LAST_FULL_NOTIFY=$now
         fi


### PR DESCRIPTION
Not much to explain here, just noticed it a few minutes ago as my laptop hit full charge.