### PR TITLE
Added persistence to performance profile

### DIFF
--- a/user_scripts/dusky_system/control_center/dusky_config.yaml
+++ b/user_scripts/dusky_system/control_center/dusky_config.yaml
@@ -96,6 +96,7 @@ pages:
       properties:
         title: Active Profile
         description: Select performance mode
+        key: performance_profile
         icon: power-profile-balanced-symbolic
         value_command: "tlpctl get"
         interval: 2
@@ -930,6 +931,7 @@ pages:
       properties:
         title: Active Profile
         description: Select performance mode
+        key: performance_profile
         icon: power-profile-balanced-symbolic
         value_command: "tlpctl get"
         interval: 2


### PR DESCRIPTION
As far as I can tell this is all that's needed to allow the selected performance profile to persist across reboots. I've tested it from both selection rows in the control center. It should be implemented in a style that agrees with how you already do persistence. This was meant to address #156.