### PR TITLE
Update appearance.conf

### DIFF
--- a/.config/hypr/source/appearance.conf
+++ b/.config/hypr/source/appearance.conf
@@ -70,7 +70,7 @@ decoration {
         range = 35
         render_power = 2        # 1-4. Higher is faster falloff (sharper looking)
         sharp = false           # If true, renders a sharp shadow (retro style)
-        ignore_window = true    # If true, shadow isn't rendered behind the window itself
+        #ignore_window = true    # If true, shadow isn't rendered behind the window itself
         scale = 1.0             # Scale of the shadow (1.0 = window size)
         color = rgba(1a1a1aee)
         # color = $primary
@@ -112,7 +112,7 @@ source = ~/.config/hypr/source/animations/active/active.conf
 # 4. LAYOUTS
 # -------------------------------------------------------------------------------------------------
 dwindle {
-    pseudotile = true
+    #pseudotile = true
     preserve_split = true
     # smart_split = false     # If true, splits based on mouse position.
     # smart_resizing = false  # If true, resizing direction is determined by mouse pos.


### PR DESCRIPTION
Hotfix for hyprland 0.55.0 breaking changes
Commented away  dwindle:pseudotile and decoration:shadow:ignore_window as these switches ar no longer present in most recent hyprland v 0.55.0.