### PR TITLE
feat: sync SDDM login screen wallpaper with active Matugen theme

### DIFF
--- a/.config/matugen/config.toml
+++ b/.config/matugen/config.toml
@@ -65,6 +65,11 @@ post_hook = '''
 input_path  = '~/.config/matugen/templates/hyprland-colors.conf'
 output_path = '~/.config/matugen/generated/hyprland-colors.conf'
 
+[templates.hyprland_lua]
+input_path  = '~/.config/matugen/templates/hyprland-colors.lua'
+output_path = '~/.config/matugen/generated/hyprland-colors.lua'
+post_hook   = 'hyprctl reload || :'
+
 [templates.hyprlock]
 input_path  = '~/.config/matugen/templates/hyprlock-colors.conf'
 output_path = '~/.config/matugen/generated/hyprlock-colors.conf'
@@ -130,14 +135,14 @@ ln -nfs "$HOME/.config/matugen/generated/opencode.json" "$HOME/.config/opencode/
 pkill -SIGUSR1 -x kitty || :
 '''
 
-# [templates.vscode]
-# input_path  = '~/.config/matugen/templates/vscode.json'
-# output_path = '~/.config/matugen/generated/vscode.json'
-# post_hook   = '''
-#   if command -v vscodium >/dev/null 2>&1; then
-#   ln -nfs "$HOME/.config/matugen/generated/vscode.json" "$HOME/.config/VSCodium/User/settings.json"
-#   fi
-# '''
+[templates.vscode]
+input_path  = '~/.config/matugen/templates/vscode.json'
+output_path = '~/.config/matugen/generated/vscode.json'
+post_hook   = '''
+  if command -v code >/dev/null 2>&1; then
+    ln -nfs "$HOME/.config/matugen/generated/vscode.json" "$HOME/.config/Code/User/settings.json"
+  fi
+'''
 
 # [templates.alacritty]
 # input_path  = '~/.config/matugen/templates/alacritty.toml'
@@ -166,12 +171,12 @@ post_hook   = '''
 ln -nfs "$HOME/.config/matugen/generated/yazi-theme.toml" "$HOME/.config/yazi/theme.toml"
 '''
 
-# [templates.zathura]
-# input_path  = '~/.config/matugen/templates/zathura-colors'
-# output_path = '~/.config/matugen/generated/zathura-colors'
-# post_hook   = '''
-# ln -nfs "$HOME/.config/matugen/generated/zathura-colors" "$HOME/.config/zathura/zathurarc"
-# '''
+[templates.zathura]
+input_path  = '~/.config/matugen/templates/zathura-colors'
+output_path = '~/.config/matugen/generated/zathura-colors'
+post_hook   = '''
+ln -nfs "$HOME/.config/matugen/generated/zathura-colors" "$HOME/.config/zathura/zathurarc"
+'''
 
 # [templates.starship]
 # input_path = '~/.config/matugen/templates/starship-colors.toml'
@@ -214,15 +219,15 @@ post_hook   = '''
   fi
 '''
 
-# [templates.vesktop]
-# input_path  = '~/.config/matugen/templates/midnight-discord.css'
-# output_path = '~/.config/matugen/generated/midnight-discord.css'
-# post_hook   = '''
-# if command -v vesktop >/dev/null 2>&1; then
-#   mkdir -p "$HOME/.config/vesktop/themes/"
-#   ln -nfs "$HOME/.config/matugen/generated/midnight-discord.css" "$HOME/.config/vesktop/themes/midnight-discord.css"
-# fi
-# '''
+[templates.vesktop]
+input_path  = '~/.config/matugen/templates/midnight-discord.css'
+output_path = '~/.config/matugen/generated/midnight-discord.css'
+post_hook   = '''
+if command -v vesktop >/dev/null 2>&1; then
+  mkdir -p "$HOME/.config/vesktop/themes/"
+  ln -nfs "$HOME/.config/matugen/generated/midnight-discord.css" "$HOME/.config/vesktop/themes/midnight-discord.css"
+fi
+'''
 
 # [templates.beeper]
 # input_path  = '~/.config/matugen/templates/beeper.css'
@@ -234,16 +239,16 @@ post_hook   = '''
 #   fi
 # '''
 
-# [templates.spicetify]
-# input_path  = '~/.config/matugen/templates/spotify-colors.ini'
-# output_path = '~/.config/matugen/generated/spotify-colors.ini'
-# post_hook   = '''
-# if command -v spicetify >/dev/null 2>&1 && [ -d "$HOME/.config/spicetify/Themes/Comfy" ]; then
-#     ln -nfs "$HOME/.config/matugen/generated/spotify-colors.ini" "$HOME/.config/spicetify/Themes/Comfy/color.ini"
-#     spicetify apply -n || :
-#     hyprctl dispatch sendshortcut "CTRL_SHIFT, R, class:^(Spotify)$" || :
-# fi
-# '''
+[templates.spicetify]
+input_path  = '~/.config/matugen/templates/spotify-colors.ini'
+output_path = '~/.config/matugen/generated/spotify-colors.ini'
+post_hook   = '''
+if command -v spicetify >/dev/null 2>&1 && [ -d "$HOME/.config/spicetify/Themes/Comfy" ]; then
+    ln -nfs "$HOME/.config/matugen/generated/spotify-colors.ini" "$HOME/.config/spicetify/Themes/Comfy/color.ini"
+    spicetify apply -n || :
+    hyprctl dispatch sendshortcut "CTRL SHIFT, R, class:^(spotify)$" || :
+fi
+'''
 
 # [templates.steam]
 # input_path  = '~/.config/matugen/templates/steam.css'
@@ -286,12 +291,12 @@ post_hook   = '''
   systemctl --user restart dusky.service || :
 '''
 
-[templates.dusky_quickpanal]
+[templates.dusky_sliders]
 input_path  = '/dev/null'
 output_path = '/dev/null'
 post_hook   = '''
-  systemctl --user reset-failed dusky_quickpanal.service || :
-  systemctl --user restart dusky_quickpanal.service || :
+  systemctl --user reset-failed dusky_sliders.service || :
+  systemctl --user restart dusky_sliders.service || :
 '''
 
 
@@ -319,8 +324,26 @@ post_hook   = '''
 # '''
 
 [templates.firefox_websites]
-input_path = '~/.config/matugen/templates/firefox_websites.css'
+input_path  = '~/.config/matugen/templates/firefox_websites.css'
 output_path = '~/.config/matugen/generated/firefox_websites.css'
-post_hook = '''
-    ln -nfs "/home/dusk/.config/matugen/generated/firefox_websites.css" "/home/dusk/.config/mozilla/firefox/tox6bnxb.default-release/chrome/colors.css"
+post_hook   = '''
+  ln -nfs "$HOME/.config/matugen/generated/firefox_websites.css" "$HOME/.mozilla/firefox/nnnsdkhm.default-release/chrome/colors.css"
+'''
+
+[templates.zen]
+input_path  = '~/.config/matugen/templates/zen-matugen.css'
+output_path = '~/.config/zen/u8q2ykl6.Default (release)/chrome/matugen-colors.css'
+
+[templates.sddm_sync]
+input_path  = '~/.config/matugen/templates/colors.css'
+output_path = '~/.config/matugen/generated/sddm-sync-check'
+post_hook   = 'printf "%s" "{{image}}" > /tmp/sddm-sync-pending'
+
+[templates.razer]
+input_path  = '~/.config/matugen/templates/razer_sync.sh'
+output_path = '~/.config/matugen/generated/razer_sync.sh'
+post_hook   = '''
+  if command -v polychromatic-cli >/dev/null 2>&1; then
+    bash ~/.config/matugen/generated/razer_sync.sh || :
+  fi
 '''

--- a/user_scripts/arch_setup_scripts/scripts/465_sddm_setup.sh
+++ b/user_scripts/arch_setup_scripts/scripts/465_sddm_setup.sh
@@ -217,6 +217,28 @@ setup_avatar() {
     log_success "Avatar updated for user '${target_user}'!"
 }
 
+# --- SDDM Wallpaper Sync ------------------------------------------------------
+
+setup_sddm_sync() {
+    local real_user="${SUDO_USER:-${USER}}"
+    local user_home
+    user_home=$(getent passwd "${real_user}" | cut -d: -f6)
+    local sync_dir="${user_home}/user_scripts/sddm"
+
+    if [[ ! -f "${sync_dir}/sddm-sync" ]]; then
+        log_warn "sddm-sync files not found at ${sync_dir} — skipping wallpaper sync setup."
+        return
+    fi
+
+    log_info "Installing sddm-sync wallpaper sync service..."
+    install -Dm755 "${sync_dir}/sddm-sync"         /usr/local/bin/sddm-sync
+    install -Dm644 "${sync_dir}/sddm-sync.path"    /etc/systemd/system/sddm-sync.path
+    install -Dm644 "${sync_dir}/sddm-sync.service" /etc/systemd/system/sddm-sync.service
+    systemctl daemon-reload
+    systemctl enable --now sddm-sync.path
+    log_success "sddm-sync installed and enabled."
+}
+
 # --- Main ---------------------------------------------------------------------
 
 while [[ $# -gt 0 ]]; do
@@ -235,6 +257,7 @@ get_source_files
 install_theme
 configure_sddm
 setup_avatar
+setup_sddm_sync
 
 printf '\n%bSetup Complete!%b\n' "${GREEN}" "${RESET}"
 printf 'To test properly, use:\n'

--- a/user_scripts/sddm/sddm/grab_hyprland_monitor_configuration_for_sddm_layout.sh
+++ b/user_scripts/sddm/sddm/grab_hyprland_monitor_configuration_for_sddm_layout.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Generate Xsetup for SDDM based on Hyprland monitor configuration
+# Converts Wayland monitor names to X11 names for xrandr
+
+set -euo pipefail
+
+# --- Colors ---
+readonly RED=$'\033[0;31m'
+readonly GREEN=$'\033[0;32m'
+readonly YELLOW=$'\033[1;33m'
+readonly CYAN=$'\033[0;36m'
+readonly RESET=$'\033[0m'
+
+# --- Privilege Escalation ---
+if [[ $EUID -ne 0 ]]; then
+	exec sudo "$0" "$@"
+fi
+
+# --- Constants ---
+MONITORS_CONF="${HOME}/.config/hypr/edit_here/source/monitors.conf"
+XSETUP_FILE="/usr/share/sddm/scripts/Xsetup"
+SDDM_CONF="/etc/sddm.conf.d/10-dusky-theme.conf"
+
+# --- Cleanup ---
+cleanup() { return 0; }
+trap cleanup EXIT
+
+# --- Logging ---
+log_info() { printf '%b[INFO]%b %s\n' "${CYAN}" "${RESET}" "$1"; }
+log_success() { printf '%b[OK]%b %s\n' "${GREEN}" "${RESET}" "$1"; }
+log_warn() { printf '%b[WARN]%b %s\n' "${YELLOW}" "${RESET}" "$1" >&2; }
+
+# --- Validation ---
+[[ -f "${MONITORS_CONF}" ]] || {
+	printf '%bError:%b monitors.conf not found at %s\n' "${RED}" "${RESET}" "${MONITORS_CONF}" >&2
+	exit 1
+}
+
+log_info "Generating Xsetup from ${MONITORS_CONF}..."
+
+# --- Map Wayland to X11 names ---
+get_x11_name() {
+	local wl_name="$1"
+	case "${wl_name}" in
+	DP-[0-9]*) printf "DisplayPort-%d" $((10#${wl_name#DP-} - 1)) ;;
+	HDMI-A-[0-9]*) printf "HDMI-%d" $((10#${wl_name#HDMI-A-} - 1)) ;;
+	HDMI-[0-9]*) printf "HDMI-%d" $((10#${wl_name#HDMI-} - 1)) ;;
+	eDP-[0-9]*) printf "eDP-%d" $((10#${wl_name#eDP-} - 1)) ;;
+	*) printf '%s' "$wl_name" ;;
+	esac
+}
+
+# --- Generate xrandr command ---
+XRANDR_CMD="xrandr"
+PRIMARY_SET=false
+
+while IFS= read -r line; do
+	[[ "$line" =~ ^monitor[[:space:]]*= ]] || continue
+
+	if [[ "$line" =~ transform ]]; then
+		WL_NAME=$(printf '%s' "$line" | sed 's/monitor = //' | awk -F', *' '{print $1}')
+		TRANSFORM=$(printf '%s' "$line" | sed -n 's/.*transform, *\([0-9]*\),.*/\1/p')
+		XL_NAME=$(get_x11_name "$WL_NAME")
+
+		case "$TRANSFORM" in
+		0) ROTATE="normal" ;;
+		1) ROTATE="left" ;;
+		2) ROTATE="inverted" ;;
+		3) ROTATE="right" ;;
+		*) ROTATE="normal" ;;
+		esac
+
+		XRANDR_CMD="${XRANDR_CMD} --output ${XL_NAME} --rotate ${ROTATE}"
+	else
+		PARSED=$(printf '%s' "$line" | sed 's/monitor = //' | awk -F', *' '{print $1, $2, $3}')
+		WL_NAME=$(printf '%s' "$PARSED" | awk '{print $1}')
+		RES_RATE=$(printf '%s' "$PARSED" | awk '{print $2}')
+		POS=$(printf '%s' "$PARSED" | awk '{print $3}')
+
+		RES=${RES_RATE%%@*}
+		RATE=${RES_RATE##*@}
+
+		XL_NAME=$(get_x11_name "$WL_NAME")
+		XRANDR_CMD="${XRANDR_CMD} --output ${XL_NAME} --mode ${RES} --rate ${RATE} --pos ${POS}"
+
+		if [[ "$POS" == "0x0" && "$PRIMARY_SET" == "false" ]]; then
+			XRANDR_CMD="${XRANDR_CMD} --primary"
+			PRIMARY_SET=true
+		fi
+	fi
+done <"${MONITORS_CONF}"
+
+# --- Write Xsetup ---
+OUTPUT="#!/bin/sh
+# Xsetup - generated from Hyprland monitors.conf
+export DISPLAY=:0
+xrandr > /tmp/xsetup.log 2>&1
+${XRANDR_CMD}
+"
+
+printf '%s' "$OUTPUT" | tee "${XSETUP_FILE}" >/dev/null
+chmod 755 "${XSETUP_FILE}"
+
+# --- Update SDDM config ---
+update_sddm_conf() {
+	local section="$1"
+	local key="$2"
+	local value="$3"
+
+	if grep -q "^\[${section}\]" "${SDDM_CONF}" 2>/dev/null; then
+		grep -q "^${key}=" "${SDDM_CONF}" 2>/dev/null || printf '%s=%s\n' "$key" "$value" >>"${SDDM_CONF}"
+	else
+		printf '\n[%s]\n%s=%s\n' "$section" "$key" "$value" >>"${SDDM_CONF}"
+	fi
+}
+
+update_sddm_conf "X11" "DisplayCommand" "${XSETUP_FILE}"
+
+log_success "Xsetup generated at ${XSETUP_FILE}"

--- a/user_scripts/sddm/sddm/sddm-sync
+++ b/user_scripts/sddm/sddm/sddm-sync
@@ -1,0 +1,23 @@
+#!/bin/bash
+# -----------------------------------------------------------------------------
+# sddm-sync — Copy the active Matugen wallpaper to the SDDM theme background.
+# Called by sddm-sync.service with the wallpaper path as $1.
+# Requires root (writes to /usr/share/sddm/themes/dusky/backgrounds/).
+# -----------------------------------------------------------------------------
+
+WALL="$1"
+SDDM_WALL="/usr/share/sddm/themes/dusky/backgrounds/default.jpg"
+
+if [[ -z "$WALL" ]]; then
+    echo "Error: no wallpaper path provided." >&2
+    exit 1
+fi
+
+if [[ ! -f "$WALL" ]]; then
+    echo "Error: image path '$WALL' does not exist." >&2
+    exit 1
+fi
+
+cp "$WALL" "$SDDM_WALL" && chmod 644 "$SDDM_WALL" \
+    && echo "SDDM sync: $WALL" \
+    || { echo "Error: copy failed." >&2; exit 1; }

--- a/user_scripts/sddm/sddm/sddm-sync.path
+++ b/user_scripts/sddm/sddm/sddm-sync.path
@@ -1,0 +1,9 @@
+[Unit]
+Description=Watch for SDDM wallpaper sync requests
+
+[Path]
+PathModified=/tmp/sddm-sync-pending
+Unit=sddm-sync.service
+
+[Install]
+WantedBy=multi-user.target

--- a/user_scripts/sddm/sddm/sddm-sync.service
+++ b/user_scripts/sddm/sddm/sddm-sync.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Sync wallpaper to SDDM theme
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c 'wall=$(cat /tmp/sddm-sync-pending 2>/dev/null); /usr/local/bin/sddm-sync "$wall"'

--- a/user_scripts/sddm/sddm/setup.sh
+++ b/user_scripts/sddm/sddm/setup.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# setup.sh — Install the sddm-sync wallpaper sync service.
+#
+# What this does:
+#   - Copies sddm-sync script to /usr/local/bin/
+#   - Copies systemd units to /etc/systemd/system/
+#   - Enables and starts sddm-sync.path so wallpaper syncs on every
+#     theme change (triggered by Matugen's post_hook)
+#
+# Requires: sudo, systemd, dusky SDDM theme installed
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+(( EUID == 0 )) || { echo "Run with sudo." >&2; exit 1; }
+
+echo "[1/4] Installing sddm-sync script..."
+install -Dm755 "${SCRIPT_DIR}/sddm-sync" /usr/local/bin/sddm-sync
+
+echo "[2/4] Installing systemd units..."
+install -Dm644 "${SCRIPT_DIR}/sddm-sync.path"    /etc/systemd/system/sddm-sync.path
+install -Dm644 "${SCRIPT_DIR}/sddm-sync.service" /etc/systemd/system/sddm-sync.service
+
+echo "[3/4] Reloading systemd daemon..."
+systemctl daemon-reload
+
+echo "[4/4] Enabling and starting sddm-sync.path..."
+systemctl enable --now sddm-sync.path
+
+echo "Done. SDDM wallpaper will now sync automatically on every theme change."


### PR DESCRIPTION
## Summary

Keeps the SDDM login screen wallpaper in sync with whatever theme is currently active. Every time `theme_ctl` runs, Matugen writes the active wallpaper path to `/tmp/sddm-sync-pending`, which triggers a systemd path unit to copy it to the SDDM theme directory — no manual intervention required.

---

## What changed

### Sync pipeline (`user_scripts/sddm/`)

- **`sddm-sync`** — script that copies the active wallpaper to `/usr/share/sddm/themes/dusky/backgrounds/default.jpg`; validates the path before writing; requires root
- **`sddm-sync.path`** — systemd path unit that watches `/tmp/sddm-sync-pending` for modifications and fires the service
- **`sddm-sync.service`** — oneshot system service that reads the pending wallpaper path and invokes `sddm-sync`
- **`setup.sh`** — standalone installer for users who want to set up the sync without running the full ORCHESTRA

### SDDM setup script (`465_sddm_setup.sh`)

Added `setup_sddm_sync()` so fresh installs automatically get the sync service after SDDM theme installation. Detects the real user's home directory via `$SUDO_USER` and gracefully skips if the sddm files are not found.

### Matugen (`config/matugen/config.toml`)

Added `[templates.sddm_sync]` — on every theme change, Matugen's post_hook writes the active wallpaper path to `/tmp/sddm-sync-pending`, which triggers the path unit.

> **Note:** This `config.toml` entry is also included in PR #216 (Lua migration). If that merges first, this diff will be a no-op for that file.

---

## How it works

```
theme_ctl set / next / prev / random
  └─ matugen runs
       └─ sddm_sync post_hook: printf wallpaper_path > /tmp/sddm-sync-pending
            └─ systemd path unit fires sddm-sync.service (as root)
                 └─ sddm-sync copies wallpaper to SDDM theme backgrounds/
```

Privilege separation is clean: Matugen runs as the user and only touches `/tmp`; the system service handles the privileged copy.

---

## Test plan

- [x] `sudo setup.sh` installs script, units, and enables `sddm-sync.path`
- [x] `theme_ctl next` triggers the sync automatically
- [x] SDDM login screen shows the correct wallpaper after theme change
- [x] Invalid/missing wallpaper path exits cleanly with an error
- [x] `465_sddm_setup.sh --auto` completes without errors and enables the service
