### PR TITLE
feat(rofi): single-click launch + frecency-aware drun search

### DIFF
--- a/.config/rofi/config.rasi
+++ b/.config/rofi/config.rasi
@@ -32,6 +32,34 @@ configuration {
     kb-custom-2:            "Alt+y";
     kb-custom-3:            "Alt+t";
     /* ─────────────────────────────────────────────────────────────────────
+       Mouse - Single primary-click activates an entry
+       (rofi's default is double-click, which is unintuitive for users
+       who reach for the mouse to pick an item from the visible list).
+       me-select-entry must be cleared first because MousePrimary is
+       bound there by default; rofi refuses to bind the same event twice.
+       ───────────────────────────────────────────────────────────────────── */
+    me-select-entry:        "";
+    me-accept-entry:        "MousePrimary";
+    /* ─────────────────────────────────────────────────────────────────────
+       Frecency-aware search
+
+       Rofi already tracks launch counts in ~/.cache/rofi3.druncache, but
+       its defaults don't use that signal once you start typing. These
+       three turn it on:
+
+         - sort + fzf      → score by match quality, with launch history
+                              breaking ties (PowerToys / Albert style).
+         - matching fuzzy  → forgiving typos ("netweok" still finds the
+                              Network apps).
+         - drun-match-fields drops `categories` so Firefox stops matching
+           every Network/WebBrowser query just because its .desktop file
+           lists those categories.
+       ───────────────────────────────────────────────────────────────────── */
+    sort:                   true;
+    sorting-method:         "fzf";
+    matching:               "fuzzy";
+    drun-match-fields:      "name,generic,exec,keywords";
+    /* ─────────────────────────────────────────────────────────────────────
        Behavior Tweaks
        ───────────────────────────────────────────────────────────────────── */
     scroll-method:          0;


### PR DESCRIPTION
Two small drun (app launcher) tweaks in `.config/rofi/config.rasi`:

### 1. Single-click launch
Rofi's default needs a double-click (or Enter) to launch the highlighted entry. `me-accept-entry: "MousePrimary"` (with `me-select-entry` cleared so the event is free) makes one primary click on any visible app launch it — the way most users expect from a launcher panel.

### 2. Frecency-aware drun search
Rofi already records launch counts in `~/.cache/rofi3.druncache`, which is why the empty-query list is already sorted by most-used. But once you start typing, the default `sort: false` ignores that signal and also matches against the `Categories` field of every `.desktop`. So typing `network` puts **Firefox** above **Dusky Network** (Firefox.desktop has `Categories=...;Network;WebBrowser`).

The four added lines fix that:
- `sort: true` + `sorting-method: "fzf"` — match quality first, launch history breaks ties (PowerToys / Albert style)
- `matching: "fuzzy"` — typo-tolerant (`netweok` still matches)
- `drun-match-fields` drops `categories` so generic tags don't hijack searches

### Risk
Diff is purely additive in `config.rasi`. No theme changes, no new packages, no existing behavior touched. Tested locally on rofi 2.0.0.

Thanks for the rice — wanted to give something back.