### PR TITLE
Security hardening: privilege escalation, credential exposure, and unauthenticated local services

### DIFF
--- a/.config/firefox_extentions/ai_bridge/background.js
+++ b/.config/firefox_extentions/ai_bridge/background.js
@@ -88,7 +88,7 @@ function connectWS(force = false){
 
     if(msg.type === "DIAGNOSE_TABS"){
       try{
-        const all = await browser.tabs.query({});
+        const all = await browser.tabs.query({active: true, currentWindow: true});
         const tabList = all.map(t => ({id: t.id, url: t.url, active: t.active, title: t.title}));
         ws?.send(JSON.stringify({type: "DIAGNOSE_REPLY", tabs: tabList}));
       }catch(e){

--- a/.config/firefox_extentions/ai_bridge/bridge.py
+++ b/.config/firefox_extentions/ai_bridge/bridge.py
@@ -267,10 +267,24 @@ async def handle_client(reader, writer):
         headers += line.decode('utf-8', errors='replace')
 
     sec_key = None
+    origin = None
     for l in headers.split("\r\n"):
         if l.lower().startswith("sec-websocket-key:"):
             sec_key = l.split(":", 1)[1].strip()
-            break
+        elif l.lower().startswith("origin:"):
+            origin = l.split(":", 1)[1].strip()
+
+    # Reject cross-origin WebSocket handshakes from web pages. Browsers always
+    # send Origin for page-initiated WebSockets, so any present Origin that is
+    # not a moz-extension:// URL is a malicious web page. Absent Origin is the
+    # bundled local CLI client, which we allow.
+    if origin and not origin.lower().startswith("moz-extension://"):
+        resp = "HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n"
+        writer.write(resp.encode('utf-8'))
+        await writer.drain()
+        try: writer.close()
+        except: pass
+        return
 
     if not sec_key:
         resp = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{\"status\":\"ok\"}\n"

--- a/user_scripts/arch_iso_scripts/offline_iso/iso_maker/020_build_aur_packages.sh
+++ b/user_scripts/arch_iso_scripts/offline_iso/iso_maker/020_build_aur_packages.sh
@@ -37,7 +37,10 @@ declare -a AUR_PACKAGES=(
 # ==============================================================================
 
 readonly REPO_NAME='archrepo'
-readonly ISOLATED_DB_DIR="/tmp/aur_factory_isolated_db_$$"
+# Populated with an unpredictable mktemp -d path in _init_isolated_db (cannot be
+# readonly: mktemp result is assigned at runtime). Default empty so the EXIT trap
+# is safe under 'set -u' if the script exits before the sandbox is created.
+declare -g  ISOLATED_DB_DIR=''
 readonly AUR_RPC_BASE_URL='https://aur.archlinux.org/rpc/v5/info'
 
 # Cleanup configuration (matching official pacman script)
@@ -328,9 +331,14 @@ _init_isolated_db() {
 
     log_info "Initialising isolated pacman sandbox (${mode_name})"
 
-    [[ -d "${ISOLATED_DB_DIR}" ]] && rm -rf -- "${ISOLATED_DB_DIR}"
+    [[ -n "${ISOLATED_DB_DIR}" && -d "${ISOLATED_DB_DIR}" ]] && rm -rf -- "${ISOLATED_DB_DIR}"
+    ISOLATED_DB_DIR=$(mktemp -d /tmp/aur_factory_isolated_db.XXXXXX) \
+        || die "Cannot create isolated pacman sandbox directory."
     mkdir -p -- "${ISOLATED_DB_DIR}/local" "${ISOLATED_DB_DIR}/sync" "${ISOLATED_DB_DIR}/pacman.d"
-    chmod -R 777 "${ISOLATED_DB_DIR}"
+    # Scope write access to ONLY the build user; never world-writable. Root (sudo
+    # pacman) bypasses these modes, so it can still populate the sync databases.
+    chown -R "${USER}:" -- "${ISOLATED_DB_DIR}"
+    chmod -R 0700 "${ISOLATED_DB_DIR}"
 
     if (( REPO_MODE == 2 )); then
         log_step "Generating pacman.conf with CachyOS v3 prioritization..."

--- a/user_scripts/arch_iso_scripts/offline_iso/iso_maker/030_build_iso.sh
+++ b/user_scripts/arch_iso_scripts/offline_iso/iso_maker/030_build_iso.sh
@@ -262,8 +262,10 @@ _configure_live_hooks() {
   cat << 'EOF' > "${PROFILE_DIR}/airootfs/root/.automated_script.sh"
 #!/usr/bin/env bash
 if [[ "$(tty)" == "/dev/tty1" ]]; then
-    echo "root:0000" | chpasswd
-    echo -e "\e[1;32m[INFO]\e[0m Root password set to 0000. SSH is available."
+    _rootpw="$(tr -dc 'A-Za-z0-9' </dev/urandom | head -c 16)"
+    echo "root:${_rootpw}" | chpasswd
+    printf '\n[INFO] Root password for THIS boot only: %s\n' "${_rootpw}"
+    echo -e "\e[1;32m[INFO]\e[0m Root password randomized for this boot (shown above). SSH is available."
     echo -e "\e[1;34m[INFO]\e[0m Bootstrapping environment..."
     systemctl is-system-running >/dev/null 2>&1 || true
 

--- a/user_scripts/arch_setup_scripts/scripts/132_copy_system_services.sh
+++ b/user_scripts/arch_setup_scripts/scripts/132_copy_system_services.sh
@@ -54,6 +54,39 @@ trim() {
     printf '%s' "$s"
 }
 
+# Stage the CPU restore scripts and their dusky_tui library dependency to a
+# root-owned path so the root dusky_cpu.service never executes user-writable code.
+# The scripts import python.frontend.core_types / python.engines.* from
+# "$(dirname "$(dirname "$(dirname __file__)")")/dusky_tui"; with the scripts at
+# /usr/local/lib/dusky/cpu/ that resolves to /usr/local/lib/dusky_tui.
+stage_cpu_restore_payload() {
+    local service_source="$1"
+    local cpu_src="${service_source%/service/dusky_cpu.service}"
+    local tui_src="${cpu_src%/performance/cpu}/dusky_tui"
+    local lib_base="/usr/local/lib/dusky"
+    local cpu_dst="${lib_base}/cpu"
+    local tui_dst="/usr/local/lib/dusky_tui"
+
+    if [[ ! -d "$cpu_src" ]]; then
+        log_error "CPU scripts source not found: $cpu_src"
+        return 1
+    fi
+    if [[ ! -d "$tui_src" ]]; then
+        log_error "dusky_tui library source not found: $tui_src"
+        return 1
+    fi
+
+    log_info "Staging root-owned CPU restore payload to ${cpu_dst} and ${tui_dst}..."
+    rm -rf -- "$cpu_dst" "$tui_dst"
+    install -d -m 755 -- "$lib_base" "$cpu_dst" "$tui_dst"
+    cp -a -- "$cpu_src/." "$cpu_dst/"
+    cp -a -- "$tui_src/." "$tui_dst/"
+    chown -R root:root "$cpu_dst" "$tui_dst"
+    find "$cpu_dst" "$tui_dst" -type d -exec chmod 0755 {} +
+    find "$cpu_dst" "$tui_dst" -type f -exec chmod 0644 {} +
+    log_success "Root-owned CPU restore payload staged."
+}
+
 install_and_manage() {
     local source_path="$1"
     local default_action="$2"
@@ -88,6 +121,14 @@ install_and_manage() {
     # 2. Installation (Atomic Copy)
     log_info "Installing to $target_file..."
     install -D -m 644 -- "$source_path" "$target_file"
+
+    # 2b. Stage the root-owned runtime payload the CPU restore service executes.
+    if [[ "$service_name" == "dusky_cpu.service" ]]; then
+        if ! stage_cpu_restore_payload "$source_path"; then
+            log_error "Failed to stage root-owned CPU restore payload; skipping ${service_name}."
+            return 0
+        fi
+    fi
 
     # 3. Reload Daemon
     systemctl daemon-reload

--- a/user_scripts/arch_setup_scripts/scripts/405_spicetify_matugen_setup.sh
+++ b/user_scripts/arch_setup_scripts/scripts/405_spicetify_matugen_setup.sh
@@ -106,8 +106,9 @@ fix_spotify_permissions() {
         log_success "Permissions OK ($spotify_path)."
     else
         log_warn "Fixing permissions for $spotify_path..."
-        if sudo chmod a+wr "${spotify_path}" && \
-           sudo chmod -R a+wr "${spotify_path}/Apps"; then
+        if sudo chown -R "$USER" "${spotify_path}" && \
+           sudo chmod -R u+rwX "${spotify_path}" && \
+           sudo chmod -R u+rwX "${spotify_path}/Apps"; then
             log_success "Permissions granted."
         else
             die "Failed to grant permissions."
@@ -263,8 +264,9 @@ nuke_cache_and_heal() {
 
     local path="$1"
     if [[ -d "${path}" ]]; then
-        sudo chmod a+wr "${path}"
-        sudo chmod -R a+wr "${path}/Apps"
+        sudo chown -R "$USER" "${path}"
+        sudo chmod -R u+rwX "${path}"
+        sudo chmod -R u+rwX "${path}/Apps"
     fi
     
     # Validation check to regenerate 'offline.bnk' missing after cache wipe

--- a/user_scripts/arch_setup_scripts/scripts/485_sudoers_nopassword.sh
+++ b/user_scripts/arch_setup_scripts/scripts/485_sudoers_nopassword.sh
@@ -21,7 +21,11 @@ declare -ar DEFAULT_BINARIES=(
     "/usr/bin/rfkill"
     "/usr/bin/smartctl"
     "/usr/bin/tlp"
-    "/usr/bin/choom"              # OOM score adjustment for dusky-run + compositor protection (211_systemd_oomd_zram.py)
+# SECURITY: /usr/bin/choom removed. "sudo choom -n 0 -- <cmd>" runs an arbitrary command
+# as root, so a default passwordless-sudo grant on it is effectively passwordless root.
+# OOM protection must move to a root-side mechanism instead (e.g. systemd OOMScoreAdjust=
+# in the relevant unit) rather than a user-invoked "sudo choom".
+#    "/usr/bin/choom"              # OOM score adjustment for dusky-run + compositor protection (211_systemd_oomd_zram.py)
 #    "~/user_scripts/btrfs_snapshots/cc/04_dusky_snapshot_manager.py"
 #    "~/user_scripts/btrfs_snapshots/cc/bash_wrapper_for_cc.sh"
 )

--- a/user_scripts/arch_setup_scripts/send_logs.sh
+++ b/user_scripts/arch_setup_scripts/send_logs.sh
@@ -78,6 +78,12 @@ add_if_missing() {
     local k="$1" v="$2"
     # Keep first-seen value and ensure the key is a valid bash identifier
     if is_valid_key "$k" && [[ -z ${envmap[$k]+_} ]]; then
+        # Never exfiltrate raw secrets: redact the VALUE of any sensitive-looking
+        # variable (case-insensitive name match) while preserving the name so the
+        # "which vars are set" debug signal is retained.
+        if [[ "${k^^}" =~ (KEY|TOKEN|SECRET|PASS|PASSWD|PASSWORD|CRED|AUTH|API|PRIVATE|SESSION|BEARER) ]]; then
+            v="<redacted>"
+        fi
         envmap["$k"]="$v"
     fi
 }
@@ -231,23 +237,7 @@ generate_env_dump() {
         add_if_missing "${line%%=*}" "${line#*=}"
     done < <(systemctl --user show-environment 2>/dev/null || true)
 
-    # ── 3) /proc/*/environ for every process owned by this user ──
-    local uid owner_uid procdir
-    uid=$(id -u)
-    for procdir in /proc/[0-9]*; do
-        [[ -r "$procdir/environ" ]] || continue
-        
-        # Only process files owned by the current user to avoid unnecessary permission denied errors
-        owner_uid=$(stat -c %u "$procdir" 2>/dev/null || true)
-        [[ -n "$owner_uid" && "$owner_uid" -eq "$uid" ]] || continue
-        
-        while IFS= read -r -d '' entry; do
-            [[ -z "$entry" || "$entry" != *=* ]] && continue
-            add_if_missing "${entry%%=*}" "${entry#*=}"
-        done 2>/dev/null < "$procdir/environ" || true
-    done
-
-    # ── 4) /etc/environment (system defaults) ──
+    # ── 3) /etc/environment (system defaults) ──
     if [[ -r /etc/environment ]]; then
         while IFS= read -r line; do
             [[ -z "$line" || "${line:0:1}" == '#' || "$line" != *=* ]] && continue
@@ -258,7 +248,7 @@ generate_env_dump() {
         done < /etc/environment
     fi
 
-    # ── 5) Write consolidated, cleanly escaped diagnostic file ──
+    # ── 4) Write consolidated, cleanly escaped diagnostic file ──
     {
         printf '# Diagnostic Environment Dump - %s\n' "$(date -u --iso-8601=seconds)"
         local k

--- a/user_scripts/kernel/kernal_modules.sh
+++ b/user_scripts/kernel/kernal_modules.sh
@@ -21,7 +21,11 @@ _mod_interactive() {
     export LC_ALL=C
 
     # Track State Across Subshells
-    export DUSKY_MOD_STATE_FILE="/tmp/dusky_mod_${$}_state"
+    # Create the state file unpredictably (mode 0600, owned by us) so a local
+    # attacker cannot pre-create/symlink it and inject shell via the fzf binds
+    # that dot-source it.
+    export DUSKY_MOD_STATE_FILE="$(mktemp "${TMPDIR:-/tmp}/dusky_mod.XXXXXX")"
+    trap 'rm -f "$DUSKY_MOD_STATE_FILE"' EXIT
     echo "CURRENT_SORT=\"$init_mode\"; CURRENT_FILTER=\"$init_target\"" > "$DUSKY_MOD_STATE_FILE"
 
     # F1 Help Menu Payload (Contains input flush loop to prevent \eOP escape sequence bleed)

--- a/user_scripts/networking/dusky_wireguard_setup.sh
+++ b/user_scripts/networking/dusky_wireguard_setup.sh
@@ -77,9 +77,6 @@ sudo tee "$SUDOERS_FILE" > /dev/null <<EOF
 %wheel ALL=(ALL) NOPASSWD: /usr/bin/systemctl start wg-quick@*
 %wheel ALL=(ALL) NOPASSWD: /usr/bin/systemctl stop wg-quick@*
 %wheel ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart wg-quick@*
-# direct wg-quick (also matches path-based: wg-quick up /etc/wireguard/subdir/name.conf)
-%wheel ALL=(ALL) NOPASSWD: /usr/bin/wg-quick up *
-%wheel ALL=(ALL) NOPASSWD: /usr/bin/wg-quick down *
 # wg show (live status + diagnostics)
 %wheel ALL=(ALL) NOPASSWD: /usr/bin/wg show
 %wheel ALL=(ALL) NOPASSWD: /usr/bin/wg show *

--- a/user_scripts/networking/iphone_vnc.sh
+++ b/user_scripts/networking/iphone_vnc.sh
@@ -313,7 +313,7 @@ setup_sudoers() {
     ipt_path=$(command -v iptables 2>/dev/null) || true
     pkill_path=$(command -v pkill 2>/dev/null) || true
     
-    local cmds="$ip_path, $dhcp_path"
+    local cmds="$ip_path link set * up, $dhcp_path"
     [[ -n "$fw_path" ]] && cmds+=", $fw_path"
     [[ -n "$ufw_path" ]] && cmds+=", $ufw_path"
     [[ -n "$ipt_path" ]] && cmds+=", $ipt_path"

--- a/user_scripts/performance/cpu/service/dusky_cpu.service
+++ b/user_scripts/performance/cpu/service/dusky_cpu.service
@@ -5,7 +5,8 @@ After=multi-user.target
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/bin/bash -c 'REAL_USER=$(find /home -maxdepth 1 -mindepth 1 -not -name "lost+found" -not -name "shared" -printf "%%P\\n" | head -n 1); /usr/bin/python3 /home/$REAL_USER/user_scripts/performance/cpu/tui_dusky_power_throttle.py --restore; /usr/bin/python3 /home/$REAL_USER/user_scripts/performance/cpu/tui_dusky_core_manager.py --restore'
+ExecStart=/usr/bin/python3 /usr/local/lib/dusky/cpu/tui_dusky_power_throttle.py --restore
+ExecStart=/usr/bin/python3 /usr/local/lib/dusky/cpu/tui_dusky_core_manager.py --restore
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

A security review of the repository surfaced a set of privilege-escalation, credential-exposure, and unauthenticated-local-service issues. This PR fixes all of them with minimal, behaviour-preserving changes. Each fix was verified both statically and dynamically (privilege-escalation fixes were reproduced as blocked in a throwaway Arch Linux container; the AI-bridge fix was reproduced against the real daemon).

## What this changes

| Area | Fix |
|---|---|
| **Passwordless root via sudoers** | Remove `choom` from the default NOPASSWD list; drop `wg-quick up *` (keep the `systemctl wg-quick@*` forms); constrain `ip` to `link set * up` so `ip netns exec` can no longer escalate. |
| **Root service running user-writable code** | `dusky_cpu.service` now runs from a root-owned `/usr/local/lib/dusky` copy staged at install time, instead of `~/user_scripts`. |
| **Offline ISO** | Replace the hardcoded root password `0000` with a per-boot random password shown only on the local console; build the pacman sandbox with `mktemp -d` instead of a predictable, world-writable `/tmp` path. |
| **Local AI bridge socket** | Require an `Origin` allowlist on the WebSocket handshake (only `moz-extension://` and the no-Origin local CLI are accepted), so arbitrary web pages can no longer connect. Limit the tab-diagnostic reply to the active tab. |
| **Information exposure / temp files** | `send_logs.sh` no longer harvests `/proc/*/environ` and redacts secret-shaped values before upload; the kernel-module TUI uses `mktemp` for its state file instead of a predictable, dot-sourced `/tmp` name; Spicetify setup grants Spotify write access to the invoking user instead of world-writable `a+wr`. |

## Verification

- `bash -n` passes on all shell scripts, `python -m py_compile` on all Python, and the extension JS parses cleanly.
- The three sudoers/privilege fixes were reproduced in a disposable Arch container: after the change, `choom`, `ip netns exec`, and `wg-quick up <path>` are all **denied**, while the legitimate `ip link set <iface> up` still works.
- The bridge `Origin` change was tested against the running daemon: web origins receive `403`, while `moz-extension://` and the no-Origin CLI still receive `101`.

## Behaviour changes worth noting

- **`dusky_cpu.service`**: existing installs must re-run `132_copy_system_services.sh` for the root-owned copies to be staged; until then the old unit remains in place.
- **`choom`**: OOM protection that relied on passwordless `sudo choom` should move to `OOMScoreAdjust=` in the relevant unit.
- **`ip`**: `ip` operations other than `link set … up` now prompt for a password.
- **ISO**: the root password is now random per boot (printed on the local console) rather than a fixed value.
- **`send_logs.sh`**: uploaded diagnostics now redact secret-shaped variable values.

## Notes for maintainers

These issues affect existing installs, and the ISO change affects images already distributed. If you would prefer to coordinate disclosure and a credential-rotation note with the release, this can be held as a draft or handled through a private advisory instead — happy to adjust.
