### PR TITLE
Update keybind cheatsheet instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ togglalble with a keybind or from rofi.
     
 - **Accessibility:** Text-to-Speech (TTS) and Speech-to-Text (STT) capabilities (hardware dependent).
     
-- **Keybind Cheatsheet:** Press `CTRL` + `SHIFT` + `?` anytime to see your controls.
+- **Keybind Cheatsheet:** Press `CTRL` + `SHIFT` + `?` or `CTRL` + `SHIFT` + `SPACE` anytime to see your controls.
     
 
 


### PR DESCRIPTION
Just updated the keybind help shortcut to include CTRL + SHIFT + SPACE.