### PR TITLE
fix(hypr): stop the vesktop matugen rule from matching the Vesktop app

### DIFF
--- a/.config/hypr/source/window_rules.lua
+++ b/.config/hypr/source/window_rules.lua
@@ -1941,10 +1941,10 @@ hl.window_rule({
     center = true
 })
 
---- 470_vesktop_matugen.sh (Vesktop Setup Script & Vesktop GUI - 80% W, 80% H Floating Dynamic) ---
+--- 470_vesktop_matugen.sh (Vesktop Setup Script ONLY - 80% W, 80% H Floating Dynamic) ---
 hl.window_rule({
     name = "470_vesktop_matugen.sh",
-    match = { class = "^(470_vesktop_matugen\\.sh|vesktop)$" },
+    match = { class = "^(470_vesktop_matugen\\.sh)$" },
     float = true,
     size = {"(monitor_w*0.80)", "(monitor_h*0.80)"},
     center = true


### PR DESCRIPTION
Fixes #330.

As requested in the issue — one-line change, in the form you pasted.

## Change

`.config/hypr/source/window_rules.lua`, lines 1944–1947:

```diff
---- 470_vesktop_matugen.sh (Vesktop Setup Script & Vesktop GUI - 80% W, 80% H Floating Dynamic) ---
+--- 470_vesktop_matugen.sh (Vesktop Setup Script ONLY - 80% W, 80% H Floating Dynamic) ---
 hl.window_rule({
     name = "470_vesktop_matugen.sh",
-    match = { class = "^(470_vesktop_matugen\\.sh|vesktop)$" },
+    match = { class = "^(470_vesktop_matugen\\.sh)$" },
     float = true,
     size = {"(monitor_w*0.80)", "(monitor_h*0.80)"},
     center = true
 })
```

The `470_vesktop_matugen.sh` window still floats at 80% × 80% exactly as before — only the Vesktop application window is no longer caught by the rule.

## Verification

- Vesktop's window class confirmed as `vesktop` on a live window (`hyprctl clients`), matching `StartupWMClass=vesktop` in the packaged `vesktop.desktop`.
- With the rule applied, Vesktop reports `floating=false` and tiles normally.
- `luac -p .config/hypr/source/window_rules.lua` passes.

Tested on CachyOS, Hyprland 0.56.2-1, vesktop-bin 1.6.7-1.

## Note

I kept the diff minimal to match what you pasted in the issue. If you'd like, I'm happy to add a short comment above the rule noting that `|vesktop` shouldn't be re-added — it would make the reason visible to anyone editing that block later. Say the word and I'll push it to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)