### PR TITLE
ml stack: cuda on nvidia, rocm on amd, gpu builds for ollama/llama.cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,10 +255,30 @@ GUI keybind invokable sliders for:
 Speech to text 
 - Whisper - for cpu 
 or 
-- Parakeet - for nvidia gpus. might also work on Amd (not sure)
+- Parakeet - for nvidia gpus (CUDA) and amd gpus (ROCm, when the ROCm stack is installed)
 
 text to speech 
 - kokoro for both cpu and gpu
+
+**ml engineering stack (opt-in)**
+
+Dusky ships vendor-matched ML tooling for nvidia (CUDA), amd (ROCm) and cpu,
+installed through the same orchestra scripts -- all opt-in, hardware-gated and
+idempotent:
+
+- ollama with the **gpu variant** for your card (ollama-cuda / ollama-rocm)
+- llama.cpp with the vendor ggml backend (cuda/hip/vulkan, straight from the repos) + a `llama-server` user service (OpenAI-compatible API on 127.0.0.1:8081)
+- LM Studio (opt-in flag), vLLM serving, JupyterLab + VS Code + project template
+- training stack: PyTorch (vendor wheels) + HuggingFace (transformers/peft/trl) + Unsloth
+- a `dusky-ml-doctor` health check for all of the above
+- boot reliability: `398_nvidia_boot_config.sh` now automates the nvidia mkinitcpio/modeset steps that used to be manual
+
+See [`user_scripts/arch_setup_scripts/ML_STACK.md`](user_scripts/arch_setup_scripts/ML_STACK.md)
+for the full matrix, sizes and how to enable each piece in `profiles/01_main.toml`.
+
+Apple notes: Intel Macs (2012-2020) are standard x86 hardware and work
+(`409_intel_mac_quirks.sh` handles Wi-Fi/keyboard quirks); Apple Silicon
+(M1-M4) needs the Asahi/ARM port and has no CUDA/ROCm -- out of scope.
 
 - mechanical keypress sounds
 togglalble with a keybind or from rofi. 

--- a/user_scripts/arch_setup_scripts/ML_STACK.md
+++ b/user_scripts/arch_setup_scripts/ML_STACK.md
@@ -1,0 +1,96 @@
+# Dusky ML/GPU Stack
+
+Vendor-matched machine-learning tooling for Arch + Hyprland, wired into the
+installer's numbered-script convention. Everything here is hardware-gated and
+idempotent -- scripts no-op cleanly on the wrong vendor.
+
+## The vendor truth table
+
+There is no universal GPU API on Linux. Each vendor has exactly one native
+compute stack, and dusky installs that one:
+
+| Vendor | Native compute | Graphics/video | Notes |
+|---|---|---|---|
+| NVIDIA | **CUDA** | NVENC/NVDEC via `nvidia-utils` | CUDA is NVIDIA-proprietary |
+| AMD | **ROCm/HIP** | VCN via mesa/VA-API | ROCm is AMD-only |
+| Intel | oneAPI/SYCL, OpenVINO | QSV via intel-media-driver | covered by existing scripts |
+| any | **Vulkan** (ggml-vulkan) | Vulkan | universal fallback (works on AMD without ROCm too) |
+
+- CUDA-on-AMD shims (ZLUDA) and ROCm-on-NVIDIA are **out of scope**: fragile,
+  perpetually broken by driver updates.
+- **Metal does not exist on Linux** (macOS only).
+- **Apple Silicon (M1-M4) is out of scope**: it requires the Asahi/ARM port of
+  Arch; GPUs there speak Mesa/Vulkan only -- no CUDA, no ROCm.
+- **Intel Macs (2012-2020) work**: they are ordinary x86_64 PCs
+  (`409_intel_mac_quirks.sh` handles Wi-Fi/keyboard/sensors).
+
+## Scripts
+
+| Script | Level | Installs | Approx. size |
+|---|---|---|---|
+| `396_amd_rocm_stack.sh` | U (sudo) | ROCm/HIP userspace: `rocm-hip-runtime rocblas hipblas miopen-hip rccl hip-runtime-amd rocm-smi-lib rocminfo`; user → `render`+`video` groups; `/etc/profile.d/10-rocm.sh` with `HSA_OVERRIDE_GFX_VERSION` when needed | ~1.1 GiB download, ~25 GiB installed (measured) |
+| `397_cuda_toolkit.sh` | U (sudo) | `cuda` + `cudnn` (+ `--tools`: nsight) for compiling/profiling CUDA code | ~2.7 GiB download, ~5.8 GiB installed (measured) |
+| `398_nvidia_boot_config.sh` | S | mkinitcpio `MODULES` + `mkinitcpio -P` + `nvidia_drm.modeset=1` for systemd-boot **and** GRUB (automates what `380` used to print) | KBs |
+| `399_ml_runtimes.sh` | U | Ollama vendor variant (`ollama-cuda`/`ollama-rocm`), llama.cpp (`llama-cpp`) with the vendor ggml backend (`ggml-cuda`/`ggml-hip`/`ggml-vulkan`, all from extra), `llama-server` user unit (OpenAI API @ 127.0.0.1:8081), `--lmstudio` opt-in (`lmstudio-bin`) | ~0.5-1 GiB |
+| `400_ml_training_stack.sh` | U | uv venv `~/.local/lib/dusky-ml/.venv`: PyTorch (CUDA/ROCm/CPU matched), `transformers peft trl datasets accelerate`, Unsloth (+bitsandbytes on NVIDIA), `dusky-ml-doctor` | ~2.5 GiB CUDA / ~2 GiB ROCm |
+| `401_ml_serving_stack.sh` | U | vLLM in a separate venv (`.venv-serving`) + `dusky-vllm` user unit (not auto-started) | ~3 GiB |
+| `402_ml_notebook_lab.sh` | U | JupyterLab + ipykernel (dusky-ml venv), VS Code, `~/Projects/ml-template` scaffold | ~0.5 GiB |
+| `409_intel_mac_quirks.sh` | S | Broadcom Wi-Fi (`broadcom-wl-dkms`), `hid_apple fnmode=2`, lm_sensors/applesmc | small |
+
+Shared detection lives in `scripts/lib/gpu_detect.sh` (sysfs + lspci + VM
+guard, same contract as `380_nvidia_open_source.sh`); every script above
+sources it.
+
+## Enabling
+
+The ML scripts are registered **commented-out** in `profiles/01_main.toml`
+(they pull multi-GiB downloads; the default profile stays lean). Uncomment
+what you want, or run directly:
+
+```bash
+~/user_scripts/arch_setup_scripts/scripts/396_amd_rocm_stack.sh --auto
+~/user_scripts/arch_setup_scripts/scripts/399_ml_runtimes.sh --auto --lmstudio
+```
+
+Every script here is opt-in (commented out in `profiles/01_main.toml`),
+including `398_nvidia_boot_config.sh` -- it edits mkinitcpio.conf and kernel
+command lines, so boot/system modifications only ever run when explicitly
+enabled. It is guarded end to end: a failed `mkinitcpio -P` restores the
+config backup instead of dying half-applied.
+
+## What runs where (after install)
+
+| Component | Path / endpoint |
+|---|---|
+| Ollama (LLM side panel backend) | `ollama.service`, API @ 127.0.0.1:11434 |
+| llama.cpp server | `systemctl --user start llama-server`, API @ 127.0.0.1:8081/v1 |
+| vLLM server | `systemctl --user start dusky-vllm` (configure `~/.config/dusky/vllm/dusky-vllm.env` first) |
+| Training venv | `~/.local/lib/dusky-ml/.venv` |
+| Health check | `dusky-ml-doctor` |
+| Project template | `cp -r ~/Projects/ml-template ~/Projects/<name>` |
+
+## Existing AI tools (already in dusky) get GPU paths too
+
+- **Kokoro TTS** already had the full CUDA/ROCm/OpenVINO/CPU matrix.
+- **Parakeet STT** previously fell back to CPU on AMD; the installer now
+  uses Arch's `python-onnxruntime-rocm` through a system-site-packages
+  worker venv (same source as Kokoro's `--rocm-source arch`) when a usable
+  ROCm stack is present -- AMD's own wheel index stops at ROCm 7.0/cp312
+  and cannot serve current Arch, so it is deliberately not used, verifies the
+  `ROCmExecutionProvider` actually binds, and bakes
+  `HSA_OVERRIDE_GFX_VERSION` into the deployed unit when the gfx target needs
+  it. No ROCm? The reliable CPU path is unchanged.
+- **LLM side panel** (`auto_config.sh`) now hints the vendor-matched Ollama
+  package instead of the CPU one.
+
+## Verification
+
+```bash
+bash -n <script>          # syntax
+shellcheck <script>       # lint
+dusky-ml-doctor           # runtime health (on the target machine)
+```
+
+Static checks pass on any host; the scripts themselves only run on Arch
+(pacman/paru/systemd are hard prerequisites, matching every other dusky
+setup script).

--- a/user_scripts/arch_setup_scripts/profiles/01_main.toml
+++ b/user_scripts/arch_setup_scripts/profiles/01_main.toml
@@ -128,6 +128,18 @@ scripts = [
     # "S | 385_waydroid_setup.sh",
     "U | 390_clipboard_persistance.py --ram --quiet",
     "S | 395_intel_media_sdk_check.sh --auto",
+    # --- ML/GPU stacks (opt-in: multi-GiB downloads; see arch_setup_scripts/ML_STACK.md) ---
+    # 398 edits mkinitcpio.conf and kernel command lines -- opt-in only, never
+    # run boot/system modifications a user did not explicitly enable.
+    # "S | 398_nvidia_boot_config.sh --auto",
+    # "U | 396_amd_rocm_stack.sh --auto",
+    # "U | 397_cuda_toolkit.sh --auto",
+    # "U | 399_ml_runtimes.sh --auto",
+    # "U | 400_ml_training_stack.sh --auto",
+    # "U | 401_ml_serving_stack.sh --auto",
+    # "U | 402_ml_notebook_lab.sh --auto",
+    # --- Apple Intel Macs only (standard x86 hardware + Wi-Fi/keyboard quirks) ---
+    # "S | 409_intel_mac_quirks.sh --auto",
     "U | dusky_sites_setup.py",
     # "U | optimize_firefox.py",
     "U | 410_waybar_swap_config.py --set waybar=15",

--- a/user_scripts/arch_setup_scripts/scripts/380_nvidia_open_source.sh
+++ b/user_scripts/arch_setup_scripts/scripts/380_nvidia_open_source.sh
@@ -374,6 +374,9 @@ main() {
     log_info "--- Installation Complete ---"
     if [[ "$HAS_NVIDIA" -eq 1 ]]; then
         echo "  [NVIDIA SPECIFIC]"
+        echo "  398_nvidia_boot_config.sh now automates the boot requirements"
+        echo "  (mkinitcpio MODULES, mkinitcpio -P, nvidia_drm.modeset=1 for"
+        echo "  systemd-boot and GRUB). To apply manually instead:"
         echo "  1. Edit /etc/mkinitcpio.conf (Add 'nvidia nvidia_modeset nvidia_uvm nvidia_drm' to MODULES)"
         echo "  2. Run 'sudo mkinitcpio -P'"
         echo "  3. Add 'nvidia_drm.modeset=1' to your kernel boot parameters."

--- a/user_scripts/arch_setup_scripts/scripts/396_amd_rocm_stack.sh
+++ b/user_scripts/arch_setup_scripts/scripts/396_amd_rocm_stack.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#d: Install the AMD ROCm compute stack (ML/HIP acceleration)
+
+# -----------------------------------------------------------------------------
+# Script: 396_amd_rocm_stack.sh
+# Purpose: Installs the ROCm/HIP userspace so AMD GPUs can accelerate ML
+#          workloads (ollama-rocm, llama-cpp with the ggml-hip backend,
+#          torch rocm wheels, onnxruntime ROCm EPs used by Kokoro TTS and
+#          Parakeet STT).
+#
+#          Vendor truth: ROCm is AMD-only. NVIDIA machines are skipped by
+#          design (CUDA is handled by 397_cuda_toolkit.sh).
+#
+#          * pacman packages: rocm-hip-runtime, rocblas, hipblas, miopen-hip,
+#            rccl, hip-runtime-amd (ships hipcc), rocm-smi-lib, rocminfo
+#          * adds the invoking user to render+video (KFD access control)
+#          * writes /etc/profile.d/10-rocm.sh with PATH +, when needed,
+#            HSA_OVERRIDE_GFX_VERSION for consumer cards without native
+#            MIOpen/rocBLAS kernels (same mapping as the Kokoro installer)
+#
+# Flags:   --auto    no prompts (still hardware-gated)
+#          --python  also install python-onnxruntime-rocm from [extra]
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+shopt -s nullglob
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/gpu_detect.sh
+source "${SCRIPT_DIR}/lib/gpu_detect.sh"
+
+AUTO_MODE=0
+WITH_PYTHON=0
+for arg in "$@"; do
+    case "$arg" in
+        --auto)   AUTO_MODE=1 ;;
+        --python) WITH_PYTHON=1 ;;
+        *) die "Unknown argument '$arg' (supported: --auto, --python)" 2 ;;
+    esac
+done
+
+if [[ $EUID -eq 0 ]]; then
+    die "Do not run as root. Run as normal user; sudo will be invoked automatically."
+fi
+
+ROCM_PKGS=(
+    "rocm-hip-runtime"   # HIP runtime + device libraries
+    "rocblas"            # BLAS on AMD GPUs
+    "hipblas"            # HIP BLAS binding layer
+    "miopen-hip"         # deep-learning primitives (conv/pool)
+    "rccl"               # multi-GPU collectives (NCCL equivalent)
+    "hip-runtime-amd"    # ships the hipcc compiler (/usr/bin/hipcc, /opt/rocm/bin/hipcc)
+    "rocm-smi-lib"       # rocm-smi monitoring
+    "rocminfo"           # topology/gfx enumeration
+)
+
+PROFILE_FILE="/etc/profile.d/10-rocm.sh"
+
+# --- groups ---------------------------------------------------------------------
+# KFD node access is granted through the render+video groups (see the Arch
+# ROCm wiki page). Idempotent; also covered by 473_add_user_to_group.sh.
+ensure_groups() {
+    local user="${SUDO_USER:-$USER}" group changed=0
+    for group in render video; do
+        if ! id -nG "$user" 2>/dev/null | tr ' ' '\n' | grep -qx "$group"; then
+            # Plain sudo (a prompt is fine); guarded so a failed sudo can never
+            # hard-trip set -e mid-install.
+            if sudo usermod -aG "$group" "$user"; then
+                changed=1
+                log_ok "Added $user to group '$group' (effective on next login)."
+            else
+                log_warn "Could not add $user to '$group'; run: sudo usermod -aG $group $user"
+            fi
+        fi
+    done
+    [[ $changed -eq 1 ]] && log_warn "Log out/in once for the new groups to apply."
+}
+
+# --- profile.d -------------------------------------------------------------------
+write_profile() {
+    local hsa_override="$1" content
+    content="# Managed by dusky 396_amd_rocm_stack.sh -- safe to edit manually\n"
+    content+="# ROCm userspace on Arch keeps binaries in /opt/rocm\n"
+    content+="export PATH=\"\$PATH:/opt/rocm/bin\"\n"
+    if [[ -n "$hsa_override" ]]; then
+        content+="# Consumer gfx target without native MIOpen/rocBLAS kernels; map to closest arch.\n"
+        content+="export HSA_OVERRIDE_GFX_VERSION=\"${hsa_override}\"\n"
+    fi
+
+    if gpu_root_write "$PROFILE_FILE" "$(printf '%b' "$content")"; then
+        log_ok "Wrote ${PROFILE_FILE}"
+        [[ -n "$hsa_override" ]] && log_ok "HSA_OVERRIDE_GFX_VERSION=${hsa_override}"
+    else
+        log_warn "Could not write ${PROFILE_FILE}; set PATH/HSA override manually."
+    fi
+}
+
+# --- main -------------------------------------------------------------------------
+main() {
+    gpu_detect_topology
+
+    if [[ "$GPU_HAS_AMD" -ne 1 ]]; then
+        log_info "No AMD GPU detected -- ROCm stack not applicable."
+        [[ "$GPU_HAS_NVIDIA" -eq 1 ]] && log_info "NVIDIA detected: use 397_cuda_toolkit.sh for CUDA."
+        exit 0
+    fi
+    if [[ "$GPU_IS_VM" -eq 1 ]]; then
+        log_warn "Virtual GPU detected -- skipping ROCm."
+        exit 0
+    fi
+
+    log_info "AMD GPU detected. ROCm provides HIP/ML acceleration (CUDA is NVIDIA-only)."
+    log_info "Measured on current [extra]: ~1.1 GiB download, ~25 GiB installed on disk."
+    log_info "(AMD ships precompiled kernels for many gfx targets inside every library.)"
+    gpu_confirm "  Install the ROCm compute stack?" "$AUTO_MODE" || { log_warn "Skipping ROCm."; exit 0; }
+
+    gpu_pacman_install "${ROCM_PKGS[@]}"
+    log_ok "ROCm packages installed."
+
+    [[ "$WITH_PYTHON" -eq 1 ]] && gpu_pacman_install "python-onnxruntime-rocm"
+
+    ensure_groups
+
+    # gfx override for consumer cards (same table as Kokoro TTS)
+    local gfx hsa_override=""
+    gfx=$(gpu_rocm_gfx) || true
+    if [[ -n "$gfx" ]]; then
+        hsa_override=$(gpu_hsa_override_for_gfx "$gfx") || true
+        if [[ -n "$hsa_override" ]]; then
+            log_warn "$gfx has no native MIOpen/rocBLAS kernels; applying HSA_OVERRIDE_GFX_VERSION=$hsa_override."
+        else
+            log_ok "ROCm target: $gfx (native kernels available)."
+        fi
+    else
+        log_warn "rocminfo reported no gfx target; continuing without HSA override."
+    fi
+    write_profile "$hsa_override"
+
+    # --- verification ---
+    [[ -e /dev/kfd ]] || log_warn "/dev/kfd missing -- amdgpu KFD not loaded; ROCm will not work until reboot."
+    if command -v rocm-smi &>/dev/null; then
+        if rocm-smi --showproductname &>/dev/null; then
+            log_ok "rocm-smi talks to the GPU."
+        else
+            log_warn "rocm-smi present but failed; check groups/reboot."
+        fi
+    fi
+    local rel
+    rel=$(gpu_rocm_release) || true
+    [[ -n "$rel" ]] && log_ok "ROCm release: $rel"
+
+    echo ""
+    log_ok "ROCm stack ready. Reboot if /dev/kfd or group membership was just added."
+    log_info "Per-tool notes:"
+    echo "   - Ollama:        399_ml_runtimes.sh installs the ollama-rocm variant"
+    echo "   - llama.cpp:     399_ml_runtimes.sh installs llama-cpp with the ggml-hip backend"
+    echo "   - Kokoro TTS:    re-run its installer and pick the AMD/ROCm backend"
+    echo "   - PyTorch:       400_ml_training_stack.sh provisions torch-rocm wheels"
+}
+
+main "$@"

--- a/user_scripts/arch_setup_scripts/scripts/397_cuda_toolkit.sh
+++ b/user_scripts/arch_setup_scripts/scripts/397_cuda_toolkit.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#d: Install the NVIDIA CUDA toolkit (nvcc, cuDNN) for ML engineering
+
+# -----------------------------------------------------------------------------
+# Script: 397_cuda_toolkit.sh
+# Purpose: Installs the CUDA toolkit + cuDNN so NVIDIA machines can compile
+#          and profile CUDA code (PyTorch/Unsloth/vLLM ship their own CUDA
+#          *runtimes*; the toolkit is for development and custom kernels).
+#
+#          Vendor truth: CUDA is NVIDIA-only. AMD machines are skipped by
+#          design (ROCm is handled by 396_amd_rocm_stack.sh).
+#
+#          * base:     cuda, cudnn
+#          * --tools:  nsight-systems, nsight-compute (profiling)
+#          * validates driver <-> toolkit compatibility via nvidia-smi
+#            (the driver's "CUDA Version" field is the max supported)
+#
+# Flags:   --auto    no prompts (still hardware-gated)
+#          --tools   add profiling/debug tooling (~4 GiB extra)
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+shopt -s nullglob
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/gpu_detect.sh
+source "${SCRIPT_DIR}/lib/gpu_detect.sh"
+
+AUTO_MODE=0
+WITH_TOOLS=0
+for arg in "$@"; do
+    case "$arg" in
+        --auto)  AUTO_MODE=1 ;;
+        --tools) WITH_TOOLS=1 ;;
+        *) die "Unknown argument '$arg' (supported: --auto, --tools)" 2 ;;
+    esac
+done
+
+if [[ $EUID -eq 0 ]]; then
+    die "Do not run as root. Run as normal user; sudo will be invoked automatically."
+fi
+
+CUDA_PKGS=("cuda" "cudnn")
+# no cuda-tools on Arch -- nsight-* are the standalone profiling packages.
+CUDA_TOOL_PKGS=("nsight-systems" "nsight-compute")
+
+# --- driver <-> toolkit compatibility --------------------------------------------
+# nvidia-smi prints "CUDA Version: X.Y" = maximum CUDA the loaded driver can
+# run. Warn (never fail) when the toolkit outruns the driver.
+check_driver_compat() {
+    if ! command -v nvidia-smi &>/dev/null; then
+        log_warn "nvidia-smi not found -- proprietary driver not installed/loaded yet."
+        log_warn "Run 380_nvidia_open_source.sh and reboot before using the toolkit."
+        return
+    fi
+    local driver_cuda driver_major
+    driver_cuda=$(nvidia-smi 2>/dev/null | grep -oE 'CUDA Version: *[0-9]+\.[0-9]+' | grep -oE '[0-9]+\.[0-9]+' | head -n1) || true
+    driver_major=$(gpu_nvidia_driver_major) || true
+    if [[ -z "$driver_cuda" ]]; then
+        log_warn "Could not read the driver's supported CUDA version."
+        return
+    fi
+    log_ok "Driver supports up to CUDA ${driver_cuda} (driver major: ${driver_major:-unknown})."
+
+    local toolkit_cuda
+    toolkit_cuda=$(pacman -Qi cuda 2>/dev/null | grep -oE 'cuda-([0-9]+\.[0-9]+)' | head -n1 | cut -d- -f2) || true
+    if [[ -n "$toolkit_cuda" ]]; then
+        if awk -v t="$toolkit_cuda" -v d="$driver_cuda" 'BEGIN { exit (t > d) ? 0 : 1 }'; then
+            log_warn "Toolkit CUDA ${toolkit_cuda} > driver-supported ${driver_cuda}: update nvidia-utils or downgrade cuda."
+        else
+            log_ok "Toolkit CUDA ${toolkit_cuda} within driver support (${driver_cuda})."
+        fi
+    fi
+}
+
+# --- main --------------------------------------------------------------------------
+main() {
+    gpu_detect_topology
+
+    if [[ "$GPU_HAS_NVIDIA" -ne 1 ]]; then
+        log_info "No NVIDIA GPU detected -- CUDA toolkit not applicable."
+        [[ "$GPU_HAS_AMD" -eq 1 ]] && log_info "AMD detected: use 396_amd_rocm_stack.sh for ROCm/HIP."
+        exit 0
+    fi
+    if [[ "$GPU_IS_VM" -eq 1 ]]; then
+        log_warn "Virtual GPU detected -- skipping CUDA toolkit."
+        exit 0
+    fi
+
+    local pkgs=("${CUDA_PKGS[@]}")
+    [[ "$WITH_TOOLS" -eq 1 ]] && pkgs+=("${CUDA_TOOL_PKGS[@]}")
+
+    log_info "NVIDIA GPU detected. The CUDA toolkit is a development stack:"
+    log_info "PyTorch/Ollama/vLLM bundle their own CUDA runtimes and do NOT need it."
+    log_info "Measured on current [extra]: ~2.7 GiB download, ~5.8 GiB installed on disk."
+    gpu_confirm "  Install the CUDA toolkit?" "$AUTO_MODE" || { log_warn "Skipping CUDA toolkit."; exit 0; }
+
+    gpu_pacman_install "${pkgs[@]}"
+    log_ok "CUDA packages installed."
+
+    # Arch puts nvcc in /usr/bin and libraries in /usr/lib -- no PATH or
+    # LD_LIBRARY_PATH changes are required (unlike upstream NVIDIA docs).
+    if command -v nvcc &>/dev/null; then
+        log_ok "nvcc: $(nvcc --version | tail -n1 | sed 's/^ *//')"
+    else
+        log_warn "nvcc not on PATH; open a new shell."
+    fi
+
+    check_driver_compat
+
+    echo ""
+    log_ok "CUDA toolkit ready."
+    log_info "Next: 400_ml_training_stack.sh provisions PyTorch + Unsloth (own CUDA runtime)."
+}
+
+main "$@"

--- a/user_scripts/arch_setup_scripts/scripts/398_nvidia_boot_config.sh
+++ b/user_scripts/arch_setup_scripts/scripts/398_nvidia_boot_config.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+#d: Apply NVIDIA boot requirements (mkinitcpio modules + nvidia_drm.modeset)
+
+# -----------------------------------------------------------------------------
+# Script: 398_nvidia_boot_config.sh
+# Purpose: Automates the post-install steps 380_nvidia_open_source.sh used to
+#          only print, which are required for a reliable NVIDIA Wayland/Hyprland
+#          boot (and that 383_configure_hyprland_gpu.py warns about when
+#          missing -- "black screen" risk):
+#
+#            1. add nvidia nvidia_modeset nvidia_uvm nvidia_drm to the
+#               MODULES array of /etc/mkinitcpio.conf
+#            2. regenerate all initramfs images (mkinitcpio -P)
+#            3. enforce nvidia_drm.modeset=1 on the kernel command line of
+#               BOTH supported bootloaders:
+#                 - systemd-boot: /boot/loader/entries/*.conf (skips -fallback)
+#                 - GRUB:         /etc/default/grub + grub-mkconfig
+#
+#          Everything is idempotent: re-running changes nothing once applied.
+#
+# Flags:   --auto        no prompts (still hardware-gated)
+#          --dry-run     show planned changes without writing
+#          --no-rebuild  edit configs but skip mkinitcpio -P
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+shopt -s nullglob
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/gpu_detect.sh
+source "${SCRIPT_DIR}/lib/gpu_detect.sh"
+
+AUTO_MODE=0
+DRY_RUN=0
+REBUILD=1
+for arg in "$@"; do
+    case "$arg" in
+        --auto)       AUTO_MODE=1 ;;
+        --dry-run)    DRY_RUN=1 ;;
+        --no-rebuild) REBUILD=0 ;;
+        *) die "Unknown argument '$arg' (supported: --auto, --dry-run, --no-rebuild)" 2 ;;
+    esac
+done
+
+MKINITCPIO_CONF="/etc/mkinitcpio.conf"
+NVIDIA_MODULES=(nvidia nvidia_modeset nvidia_uvm nvidia_drm)
+MODESET_PARAM="nvidia_drm.modeset=1"
+
+# --- privilege escalation (381 pattern) ------------------------------------------
+if [[ $EUID -ne 0 ]]; then
+    printf "[\033[0;33mINFO\033[0m] Escalating permissions to root...\n"
+    exec sudo "$0" "$@"
+fi
+
+# --- 1. mkinitcpio MODULES ---------------------------------------------------------
+# Rewrites the active MODULES=(...) line adding only the missing modules in a
+# single awk pass; appends a fresh line when no active MODULES exists.
+# Keeps every other line byte-identical; backs up once to .bak.dusky.
+patch_mkinitcpio() {
+    [[ -f "$MKINITCPIO_CONF" ]] || { log_warn "$MKINITCPIO_CONF not found; skipping."; return; }
+
+    local missing=() m
+    for m in "${NVIDIA_MODULES[@]}"; do
+        grep -qE "^MODULES=.*\b${m}\b" "$MKINITCPIO_CONF" || missing+=("$m")
+    done
+
+    if [[ ${#missing[@]} -eq 0 ]]; then
+        log_ok "mkinitcpio MODULES already contain the NVIDIA set."
+        return
+    fi
+    log_info "Adding to MODULES: ${missing[*]}"
+
+    [[ "$DRY_RUN" -eq 1 ]] && { log_info "[dry-run] would edit $MKINITCPIO_CONF"; return; }
+
+    cp -n "$MKINITCPIO_CONF" "${MKINITCPIO_CONF}.bak.dusky"
+    local tmp
+    tmp=$(mktemp) || die "mktemp failed"
+    awk -v extra="${missing[*]}" '
+        /^MODULES=\(/ && !done {
+            line=$0
+            sub(/\)$/, " " extra ")", line)
+            print line
+            done=1
+            next
+        }
+        { print }
+        END { if (!done) print "MODULES=(" extra ")" }
+    ' "$MKINITCPIO_CONF" >"$tmp" && cat "$tmp" >"$MKINITCPIO_CONF"
+    rm -f "$tmp"
+    log_ok "MODULES updated in $MKINITCPIO_CONF (backup: ${MKINITCPIO_CONF}.bak.dusky)."
+}
+
+# --- 2. kernel command line ---------------------------------------------------------
+
+# Ensures $MODESET_PARAM on every options line of an entry file.
+patch_systemd_boot_entry() {
+    local entry="$1" line out="" changed=0
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^[[:space:]]*options ]]; then
+            if grep -qE 'nvidia_drm\.modeset=' <<<"$line"; then
+                if [[ "$line" != *"$MODESET_PARAM"* ]]; then
+                    line=$(sed -E 's/nvidia_drm\.modeset=[^ ]+/'"$MODESET_PARAM"'/' <<<"$line")
+                    changed=1
+                fi
+            else
+                line="${line} ${MODESET_PARAM}"
+                changed=1
+            fi
+        fi
+        out+="${line}"$'\n'
+    done <"$entry"
+
+    if [[ $changed -eq 1 ]]; then
+        [[ "$DRY_RUN" -eq 1 ]] && { log_info "[dry-run] would edit $entry"; return; }
+        cp -n "$entry" "${entry}.bak.dusky" 2>/dev/null || true   # FAT32 may refuse
+        printf '%s' "$out" >"$entry"
+        log_ok "Enforced $MODESET_PARAM in $(basename "$entry")."
+    fi
+}
+
+patch_systemd_boot() {
+    local entries_dir="/boot/loader/entries"
+    [[ -d "$entries_dir" ]] || { log_info "No systemd-boot entries at $entries_dir."; return; }
+    local entry found=0
+    for entry in "$entries_dir"/*.conf; do
+        [[ "$entry" == *-fallback* ]] && continue   # primary kernels only (320 policy)
+        found=1
+        patch_systemd_boot_entry "$entry"
+    done
+    [[ $found -eq 0 ]] && log_info "No primary systemd-boot entries found."
+}
+
+patch_grub() {
+    local grub_default="/etc/default/grub"
+    [[ -f "$grub_default" ]] || { log_info "GRUB not installed (/etc/default/grub missing)."; return; }
+
+    if grep -qE '^GRUB_CMDLINE_LINUX(_DEFAULT)?=.*nvidia_drm\.modeset=' "$grub_default"; then
+        log_ok "GRUB command line already sets nvidia_drm.modeset."
+    else
+        log_info "Appending $MODESET_PARAM to GRUB_CMDLINE_LINUX_DEFAULT."
+        if [[ "$DRY_RUN" -ne 1 ]]; then
+            cp -n "$grub_default" "${grub_default}.bak.dusky"
+            sed -E -i 's|^(GRUB_CMDLINE_LINUX_DEFAULT=")(.*)(")$|\1\2 '"$MODESET_PARAM"'\3|' "$grub_default"
+            log_ok "Updated $grub_default."
+            if command -v grub-mkconfig &>/dev/null && [[ -d /boot/grub ]]; then
+                if grub-mkconfig -o /boot/grub/grub.cfg; then
+                    log_ok "Regenerated /boot/grub/grub.cfg."
+                else
+                    log_warn "grub-mkconfig failed; /etc/default/grub was edited, regenerate grub.cfg manually."
+                fi
+            else
+                log_warn "grub-mkconfig unavailable; regenerate grub.cfg manually."
+            fi
+        fi
+    fi
+}
+
+# --- main ------------------------------------------------------------------------------
+main() {
+    gpu_detect_topology
+
+    if [[ "$GPU_HAS_NVIDIA" -ne 1 ]]; then
+        log_info "No NVIDIA GPU detected -- nothing to configure."
+        exit 0
+    fi
+
+    if ! pacman -Qq nvidia-utils &>/dev/null && ! lsmod 2>/dev/null | grep -q '^nvidia '; then
+        log_warn "NVIDIA hardware present but the proprietary driver is not installed."
+        log_warn "Run 380_nvidia_open_source.sh first; aborting to avoid an unbootable initramfs."
+        exit 0
+    fi
+
+    log_info "NVIDIA detected. This script applies the boot requirements for"
+    log_info "Wayland/Hyprland (early KMS): $MODESET_PARAM + initramfs modules."
+    gpu_confirm "  Apply NVIDIA boot configuration?" "$AUTO_MODE" || { log_warn "Skipping."; exit 0; }
+
+    patch_mkinitcpio
+
+    if [[ "$REBUILD" -eq 1 && "$DRY_RUN" -ne 1 ]]; then
+        if command -v mkinitcpio &>/dev/null; then
+            log_info "Rebuilding initramfs images (mkinitcpio -P)..."
+            if ! mkinitcpio -P; then
+                # A failed rebuild after the MODULES edit would leave the
+                # system with a modified config and no fresh images -- roll
+                # the config back and stop loudly instead of crashing.
+                if [[ -f "${MKINITCPIO_CONF}.bak.dusky" ]]; then
+                    cp -f "${MKINITCPIO_CONF}.bak.dusky" "$MKINITCPIO_CONF"
+                    log_warn "mkinitcpio failed; restored ${MKINITCPIO_CONF} from backup."
+                else
+                    log_warn "mkinitcpio failed; no backup to restore -- edit ${MKINITCPIO_CONF} by hand."
+                fi
+                log_err "Initramfs rebuild failed (often a missing module or kernel headers)."
+                log_err "Fix the cause and re-run; nothing else was changed."
+                exit 1
+            fi
+            log_ok "Initramfs rebuilt."
+        else
+            log_warn "mkinitcpio not found; initramfs not regenerated."
+        fi
+    fi
+
+    patch_systemd_boot
+    patch_grub
+
+    echo ""
+    log_ok "NVIDIA boot configuration complete. Reboot to activate."
+}
+
+main "$@"

--- a/user_scripts/arch_setup_scripts/scripts/399_ml_runtimes.sh
+++ b/user_scripts/arch_setup_scripts/scripts/399_ml_runtimes.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+#d: Install ML runtimes (Ollama GPU variant, llama.cpp, optional LM Studio)
+
+# -----------------------------------------------------------------------------
+# Script: 399_ml_runtimes.sh
+# Purpose: Installs the local-LLM runtimes with vendor-matched GPU builds so
+#          inference actually lands on the GPU:
+#
+#            Ollama    NVIDIA -> ollama-cuda     (extra)
+#                      AMD    -> ollama-rocm     (extra, needs 396 ROCm stack)
+#                      else   -> ollama          (extra, CPU)
+#            llama.cpp NVIDIA -> llama-cpp + ggml-cuda   (extra)
+#                      AMD    -> llama-cpp + ggml-hip    (extra, needs 396)
+#                      else   -> llama-cpp + ggml-vulkan (extra, any GPU with
+#                               a Vulkan driver -- including AMD without ROCm)
+#            LM Studio opt-in only (--lmstudio): AUR 'lmstudio-bin', CUDA on
+#                      NVIDIA, Vulkan on AMD (no ROCm build exists)
+#
+#          Also installs the llama-server systemd user unit
+#          (user_scripts/llm/llama_server/) exposing an OpenAI-compatible
+#          API on 127.0.0.1:8081 -- not auto-started.
+#
+# Flags:   --auto       no prompts (still hardware-gated)
+#          --lmstudio   also install LM Studio (AUR, ~500 MiB)
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+shopt -s nullglob
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/gpu_detect.sh
+source "${SCRIPT_DIR}/lib/gpu_detect.sh"
+
+AUTO_MODE=0
+WITH_LMSTUDIO=0
+for arg in "$@"; do
+    case "$arg" in
+        --auto)     AUTO_MODE=1 ;;
+        --lmstudio) WITH_LMSTUDIO=1 ;;
+        *) die "Unknown argument '$arg' (supported: --auto, --lmstudio)" 2 ;;
+    esac
+done
+
+if [[ $EUID -eq 0 ]]; then
+    die "Do not run as root. Run as normal user; sudo will be invoked automatically."
+fi
+
+LLAMA_SERVER_SRC="${SCRIPT_DIR}/../../llm/llama_server"
+SYSTEMD_USER_DIR="${HOME}/.config/systemd/user"
+LLAMA_SERVER_CONF_DIR="${HOME}/.config/dusky/llama_server"
+LLAMA_MODEL_DIR="${HOME}/.local/share/dusky-llama/models"
+
+# --- Ollama -------------------------------------------------------------------------
+install_ollama() {
+    local variant="ollama"
+    if [[ "$GPU_HAS_NVIDIA" -eq 1 ]]; then
+        variant="ollama-cuda"
+    elif [[ "$GPU_HAS_AMD" -eq 1 ]]; then
+        if gpu_rocm_available; then
+            variant="ollama-rocm"
+        else
+            log_warn "AMD GPU present but no ROCm stack (run 396_amd_rocm_stack.sh)."
+            log_warn "Installing CPU ollama; re-run after 396 for the ROCm build."
+        fi
+    fi
+
+    local installed
+    installed=$(pacman -Qq 2>/dev/null | grep -E '^ollama(-cuda|-rocm)?$' | head -n1) || true
+
+    if [[ "$installed" == "$variant" ]]; then
+        log_ok "Ollama already installed as '$variant'."
+    elif [[ -n "$installed" && "$installed" != "ollama" && "$variant" == "ollama" ]]; then
+        log_ok "GPU-specific '$installed' installed; keeping it (superset of CPU ollama)."
+    elif [[ -n "$installed" ]]; then
+        log_info "Replacing '$installed' with '$variant' for GPU acceleration..."
+        gpu_pacman_install "$variant"
+    else
+        log_info "Installing Ollama ('$variant')..."
+        gpu_pacman_install "$variant"
+    fi
+
+    if systemctl is-active --quiet ollama.service 2>/dev/null; then
+        log_ok "ollama.service is running."
+    else
+        log_info "Starting ollama.service..."
+        sudo -n systemctl enable --now ollama.service 2>/dev/null \
+            || systemctl --user enable --now ollama.service 2>/dev/null \
+            || log_warn "Could not start ollama.service; start it manually."
+    fi
+}
+
+# --- llama.cpp ------------------------------------------------------------------------
+# Arch packages llama.cpp's compute backends as separate ggml packages in
+# [extra], so the vendor-matched GPU build is a plain pacman install:
+#   ggml-cuda   (NVIDIA, pulls the cuda toolkit)
+#   ggml-hip    (AMD, pulls the same ROCm stack 396 installs)
+#   ggml-vulkan (anything with a Vulkan driver -- including AMD without ROCm)
+install_llama_cpp() {
+    local pkgs=("llama-cpp")
+    local backend="ggml-vulkan"
+    if [[ "$GPU_HAS_NVIDIA" -eq 1 ]]; then
+        backend="ggml-cuda"
+    elif [[ "$GPU_HAS_AMD" -eq 1 ]] && gpu_rocm_available; then
+        backend="ggml-hip"
+    fi
+    pkgs+=("$backend")
+    log_info "Installing llama.cpp with the $backend backend..."
+    gpu_pacman_install "${pkgs[@]}"
+    if command -v llama-server &>/dev/null; then
+        log_ok "llama-server: $(command -v llama-server)"
+    else
+        log_warn "llama-server binary not found on PATH."
+    fi
+}
+
+# --- llama-server user unit --------------------------------------------------------------
+install_llama_server_unit() {
+    [[ -f "${LLAMA_SERVER_SRC}/llama-server.service" ]] || { log_warn "llama-server unit source missing; skipping."; return; }
+
+    mkdir -p "$SYSTEMD_USER_DIR" "$LLAMA_SERVER_CONF_DIR" "$LLAMA_MODEL_DIR"
+
+    cp -f "${LLAMA_SERVER_SRC}/llama-server.service" "${SYSTEMD_USER_DIR}/llama-server.service"
+    if [[ ! -f "${LLAMA_SERVER_CONF_DIR}/llama-server.env" ]]; then
+        cp -f "${LLAMA_SERVER_SRC}/llama-server.env" "${LLAMA_SERVER_CONF_DIR}/llama-server.env"
+    fi
+    if command -v systemctl &>/dev/null; then
+        # Tolerate environments where no user manager is running (containers,
+        # non-lingering ssh sessions): the unit is still installed correctly.
+        systemctl --user daemon-reload 2>/dev/null \
+            || log_warn "user systemd manager not reachable; unit installed but not reloaded."
+    else
+        log_warn "systemctl not available; unit installed but not reloaded."
+    fi
+    log_ok "llama-server user unit installed (NOT started -- see ~/.config/dusky/llama_server/)."
+    log_info "Start it with:   systemctl --user start llama-server"
+    log_info "Endpoint:        http://127.0.0.1:8081/v1"
+}
+
+# --- LM Studio (opt-in) --------------------------------------------------------------------
+install_lmstudio() {
+    log_info "LM Studio: proprietary desktop app (AUR 'lmstudio-bin', ~500 MiB download)."
+    log_info "GPU support inside LM Studio: CUDA on NVIDIA, Vulkan on AMD (no ROCm build exists)."
+    gpu_aur_install "lmstudio-bin"
+}
+
+# --- main -------------------------------------------------------------------------------------
+main() {
+    gpu_detect_topology
+    log_info "Primary GPU vendor: ${GPU_PRIMARY_VENDOR:-none detected}"
+
+    log_info "Installing Ollama (runtime for the Dusky LLM side panel)..."
+    install_ollama
+
+    if gpu_confirm "  Install llama.cpp (vendor-matched build)?" "$AUTO_MODE"; then
+        install_llama_cpp
+    else
+        log_warn "Skipping llama.cpp."
+    fi
+
+    install_llama_server_unit
+
+    if [[ "$WITH_LMSTUDIO" -eq 1 ]]; then
+        install_lmstudio
+    fi
+
+    echo ""
+    log_ok "ML runtimes installed."
+    log_info "Next (opt-in, in profiles/01_main.toml):"
+    echo "   400_ml_training_stack.sh  PyTorch + HuggingFace + Unsloth"
+    echo "   401_ml_serving_stack.sh   vLLM serving"
+    echo "   402_ml_notebook_lab.sh    JupyterLab + VS Code + project template"
+}
+
+main "$@"

--- a/user_scripts/arch_setup_scripts/scripts/400_ml_training_stack.sh
+++ b/user_scripts/arch_setup_scripts/scripts/400_ml_training_stack.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#d: Provision the ML training stack (PyTorch + HuggingFace + Unsloth)
+
+# -----------------------------------------------------------------------------
+# Script: 400_ml_training_stack.sh
+# Purpose: Creates an isolated uv venv at ~/.local/lib/dusky-ml/.venv with
+#          vendor-matched PyTorch and the fine-tuning ecosystem:
+#
+#            PyTorch        NVIDIA -> PyPI wheels (CUDA runtime bundled)
+#                           AMD    -> download.pytorch.org/whl/rocm wheels
+#                           else   -> PyPI wheels (CPU)
+#            HuggingFace    transformers, peft, trl, datasets, accelerate,
+#                           huggingface-hub
+#            Unsloth        unsloth + unsloth_zoo (CUDA first-class; on AMD
+#                           ROCm support is partial -- installed best-effort)
+#            NVIDIA extras  bitsandbytes (skipped on AMD: no official build)
+#
+#          Also installs ~/.local/bin/dusky-ml-doctor
+#          (from user_scripts/llm/ml_stack/dusky_ml_doctor.py).
+#
+# Flags:   --auto           no prompts (still hardware-gated)
+#          --rocm-index URL override the PyTorch ROCm wheel index
+#                           (default: https://download.pytorch.org/whl/rocm6.3)
+#          --cpu            force CPU wheels even when a GPU is present
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+shopt -s nullglob
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/gpu_detect.sh
+source "${SCRIPT_DIR}/lib/gpu_detect.sh"
+
+AUTO_MODE=0
+FORCE_CPU=0
+ROCM_INDEX="https://download.pytorch.org/whl/rocm6.3"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --auto)       AUTO_MODE=1 ;;
+        --cpu)        FORCE_CPU=1 ;;
+        --rocm-index) [[ $# -ge 2 ]] || die "--rocm-index needs a URL"; ROCM_INDEX="$2"; shift ;;
+        *) die "Unknown argument '$1' (supported: --auto, --cpu, --rocm-index URL)" 2 ;;
+    esac
+    shift
+done
+
+if [[ $EUID -eq 0 ]]; then
+    die "Do not run as root. Run as normal user."
+fi
+
+ML_HOME="${HOME}/.local/lib/dusky-ml"
+ML_VENV="${ML_HOME}/.venv"
+DOCTOR_SRC="${SCRIPT_DIR}/../../llm/ml_stack/dusky_ml_doctor.py"
+BIN_DIR="${HOME}/.local/bin"
+
+HF_PACKAGES=(transformers peft trl datasets accelerate huggingface-hub)
+
+# --- main -------------------------------------------------------------------------
+main() {
+    gpu_detect_topology
+    command -v uv &>/dev/null || gpu_pacman_install "uv"
+    command -v uv &>/dev/null || die "uv is required (pacman -S uv)."
+
+    local backend="cpu"
+    if [[ "$FORCE_CPU" -eq 0 ]]; then
+        if [[ "$GPU_HAS_NVIDIA" -eq 1 ]]; then
+            backend="cuda"
+        elif [[ "$GPU_HAS_AMD" -eq 1 ]] && gpu_rocm_available; then
+            backend="rocm"
+        elif [[ "$GPU_HAS_AMD" -eq 1 ]]; then
+            log_warn "AMD GPU present but no ROCm stack (run 396_amd_rocm_stack.sh); using CPU wheels."
+        fi
+    fi
+
+    log_info "Provisioning dusky-ml venv at ${ML_VENV} (backend: ${backend})."
+    log_info "Wheel downloads are large: ~2.5 GiB CUDA / ~2 GiB ROCm / ~200 MiB CPU."
+    gpu_confirm "  Install the ML training stack?" "$AUTO_MODE" || { log_warn "Skipping."; exit 0; }
+
+    mkdir -p "$ML_HOME" "$BIN_DIR"
+    if [[ ! -x "${ML_VENV}/bin/python" ]]; then
+        uv venv --python-preference only-system "$ML_VENV"
+    fi
+    local vpy="${ML_VENV}/bin/python"
+
+    # --- PyTorch, vendor-matched ------------------------------------------------
+    case "$backend" in
+        cuda)
+            # PyPI linux wheels bundle the CUDA runtime -- no toolkit needed.
+            uv pip install --python "$vpy" torch torchvision torchaudio
+            ;;
+        rocm)
+            # ROCm wheels live on a dedicated index; PyPI torch has no HIP.
+            uv pip install --python "$vpy" torch torchvision torchaudio --index-url "$ROCM_INDEX"
+            ;;
+        *)
+            uv pip install --python "$vpy" torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+            ;;
+    esac
+    log_ok "PyTorch installed (${backend})."
+
+    # --- HuggingFace fine-tuning core --------------------------------------------
+    uv pip install --python "$vpy" "${HF_PACKAGES[@]}"
+    log_ok "HuggingFace stack installed: ${HF_PACKAGES[*]}"
+
+    # --- Unsloth --------------------------------------------------------------------
+    if [[ "$backend" == "cuda" ]]; then
+        uv pip install --python "$vpy" unsloth unsloth_zoo
+        log_ok "Unsloth installed (CUDA first-class support)."
+    elif [[ "$backend" == "rocm" ]]; then
+        log_warn "Unsloth on AMD/ROCm is best-effort (upstream targets CUDA)."
+        if gpu_confirm "  Attempt Unsloth install anyway?" "$AUTO_MODE"; then
+            uv pip install --python "$vpy" unsloth unsloth_zoo
+        else
+            log_warn "Skipping Unsloth."
+        fi
+    else
+        log_info "Unsloth requires a GPU; skipping on CPU backend."
+    fi
+
+    # --- vendor-gated extras ----------------------------------------------------------
+    if [[ "$backend" == "cuda" ]]; then
+        uv pip install --python "$vpy" bitsandbytes
+        log_ok "bitsandbytes installed (NVIDIA)."
+    fi
+
+    # --- doctor -----------------------------------------------------------------------
+    if [[ -f "$DOCTOR_SRC" ]]; then
+        install -D -m 0755 "$DOCTOR_SRC" "${BIN_DIR}/dusky-ml-doctor"
+        log_ok "Installed ${BIN_DIR}/dusky-ml-doctor"
+    else
+        log_warn "dusky_ml_doctor.py source not found; skipping doctor install."
+    fi
+
+    echo ""
+    log_ok "ML training stack ready."
+    echo "   python:      ${vpy}"
+    echo "   health check: ${BIN_DIR}/dusky-ml-doctor"
+    echo "   quick start:  ${vpy} -c 'import torch; print(torch.__version__, torch.cuda.is_available() or torch.version.hip)'"
+}
+
+main "$@"

--- a/user_scripts/arch_setup_scripts/scripts/401_ml_serving_stack.sh
+++ b/user_scripts/arch_setup_scripts/scripts/401_ml_serving_stack.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+#d: Install the ML serving stack (vLLM) with a systemd user unit
+
+# -----------------------------------------------------------------------------
+# Script: 401_ml_serving_stack.sh
+# Purpose: Provisions vLLM in its own venv (~/.local/lib/dusky-ml/.venv-serving,
+#          separate from the training venv: vLLM pins conflict with Unsloth's)
+#          and installs a dusky-vllm systemd user unit (not auto-started).
+#
+#            NVIDIA -> vllm (PyPI, first-class CUDA support)
+#            AMD    -> vllm-rocm (PyPI, published by AMD; best-effort)
+#            else   -> skipped (use llama-server from 399_ml_runtimes.sh)
+#
+# Flags:   --auto      no prompts (still hardware-gated)
+#          --no-vllm   only install the user unit, skip the vLLM venv
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+shopt -s nullglob
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/gpu_detect.sh
+source "${SCRIPT_DIR}/lib/gpu_detect.sh"
+
+AUTO_MODE=0
+NO_VLLM=0
+for arg in "$@"; do
+    case "$arg" in
+        --auto)   AUTO_MODE=1 ;;
+        --no-vllm) NO_VLLM=1 ;;
+        *) die "Unknown argument '$arg' (supported: --auto, --no-vllm)" 2 ;;
+    esac
+done
+
+if [[ $EUID -eq 0 ]]; then
+    die "Do not run as root. Run as normal user."
+fi
+
+ML_HOME="${HOME}/.local/lib/dusky-ml"
+SERVE_VENV="${ML_HOME}/.venv-serving"
+SYSTEMD_USER_DIR="${HOME}/.config/systemd/user"
+VLLM_CONF_DIR="${HOME}/.config/dusky/vllm"
+VLLM_UNIT="${SYSTEMD_USER_DIR}/dusky-vllm.service"
+
+# --- vLLM venv -------------------------------------------------------------------
+install_vllm() {
+    local pkg="vllm"
+    if [[ "$GPU_HAS_AMD" -eq 1 && "$GPU_HAS_NVIDIA" -ne 1 ]]; then
+        pkg="vllm-rocm"
+        log_warn "vllm-rocm is AMD's build; quality tracks AMD's release cadence, not PyPI vllm."
+    fi
+
+    mkdir -p "$ML_HOME"
+    if [[ ! -x "${SERVE_VENV}/bin/python" ]]; then
+        uv venv --python-preference only-system "$SERVE_VENV"
+    fi
+    uv pip install --python "${SERVE_VENV}/bin/python" "$pkg"
+    log_ok "Installed ${pkg} into ${SERVE_VENV}"
+}
+
+# --- user unit ----------------------------------------------------------------------
+install_unit() {
+    mkdir -p "$SYSTEMD_USER_DIR" "$VLLM_CONF_DIR"
+
+    if [[ ! -f "${VLLM_CONF_DIR}/dusky-vllm.env" ]]; then
+        cat >"${VLLM_CONF_DIR}/dusky-vllm.env" <<'EOF'
+# dusky-vllm options -- installed by 401_ml_serving_stack.sh, edit freely.
+# VLLM_SERVE_ARGS is passed verbatim to `vllm serve`.
+# Example:
+#   VLLM_SERVE_ARGS=Qwen/Qwen2.5-1.5B-Instruct --port 8000
+# Set your token once (read by many HF tools):
+#   HF_TOKEN=hf_...
+VLLM_SERVE_ARGS=
+HF_TOKEN=
+EOF
+        log_ok "Wrote ${VLLM_CONF_DIR}/dusky-vllm.env"
+    fi
+
+    cat >"$VLLM_UNIT" <<EOF
+# ~/.config/systemd/user/dusky-vllm.service
+# Installed by 401_ml_serving_stack.sh; NOT auto-started (a loaded model
+# pins VRAM). Start manually:
+#   systemctl --user start dusky-vllm
+# OpenAI-compatible endpoint is whatever --port says (default 8000).
+[Unit]
+Description=Dusky vLLM OpenAI-compatible server
+Documentation=https://docs.vllm.ai
+PartOf=graphical-session.target
+After=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=/bin/sh -c 'exec ${SERVE_VENV}/bin/vllm serve \$VLLM_SERVE_ARGS'
+EnvironmentFile=%h/.config/dusky/vllm/dusky-vllm.env
+Restart=on-failure
+RestartSec=3
+# GPU access (/dev/nvidia*, /dev/kfd, /dev/dri) lives in the user session.
+NoNewPrivileges=yes
+
+[Install]
+WantedBy=default.target
+EOF
+    if command -v systemctl &>/dev/null; then
+        systemctl --user daemon-reload
+    else
+        log_warn "systemctl not available; unit installed but not reloaded."
+    fi
+    log_ok "Installed ${VLLM_UNIT} (NOT started)."
+    log_info "Configure: ${VLLM_CONF_DIR}/dusky-vllm.env"
+    log_info "Start:     systemctl --user start dusky-vllm"
+}
+
+# --- main ------------------------------------------------------------------------------
+main() {
+    gpu_detect_topology
+
+    if [[ "$GPU_HAS_NVIDIA" -ne 1 && "$GPU_HAS_AMD" -ne 1 ]]; then
+        log_info "No NVIDIA/AMD GPU detected -- vLLM is GPU-only; skipping."
+        log_info "For CPU serving use llama-server (399_ml_runtimes.sh)."
+        exit 0
+    fi
+
+    command -v uv &>/dev/null || gpu_pacman_install "uv"
+    command -v uv &>/dev/null || die "uv is required (pacman -S uv)."
+
+    log_info "Serving stack: vLLM (own venv, isolated from training pins) + user unit."
+    gpu_confirm "  Install the serving stack?" "$AUTO_MODE" || { log_warn "Skipping."; exit 0; }
+
+    [[ "$NO_VLLM" -eq 0 ]] && install_vllm
+    install_unit
+
+    echo ""
+    log_ok "Serving stack ready."
+    log_info "Health check everything with: dusky-ml-doctor"
+}
+
+main "$@"

--- a/user_scripts/arch_setup_scripts/scripts/402_ml_notebook_lab.sh
+++ b/user_scripts/arch_setup_scripts/scripts/402_ml_notebook_lab.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+#d: Install the ML notebook lab (JupyterLab, VS Code, project template)
+
+# -----------------------------------------------------------------------------
+# Script: 402_ml_notebook_lab.sh
+# Purpose: Everyday ML engineering environment:
+#
+#            * JupyterLab + ipykernel into the dusky-ml venv
+#              (creates the venv CPU-only if 400 has not run yet)
+#            * VS Code from [extra] (--code-bin switches to the Microsoft
+#              binary build from AUR, with the extension marketplace)
+#            * ~/Projects/ml-template/ -- uv-based starter project
+#              (pyproject.toml, .gitignore, notebooks/, src/)
+#
+# Flags:   --auto      no prompts
+#          --code-bin  install visual-studio-code-bin (AUR) instead of code
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+shopt -s nullglob
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/gpu_detect.sh
+source "${SCRIPT_DIR}/lib/gpu_detect.sh"
+
+AUTO_MODE=0
+CODE_BIN=0
+for arg in "$@"; do
+    case "$arg" in
+        --auto)    AUTO_MODE=1 ;;
+        --code-bin) CODE_BIN=1 ;;
+        *) die "Unknown argument '$arg' (supported: --auto, --code-bin)" 2 ;;
+    esac
+done
+
+if [[ $EUID -eq 0 ]]; then
+    die "Do not run as root. Run as normal user."
+fi
+
+ML_HOME="${HOME}/.local/lib/dusky-ml"
+ML_VENV="${ML_HOME}/.venv"
+TEMPLATE_DIR="${HOME}/Projects/ml-template"
+
+# --- Jupyter -------------------------------------------------------------------------
+install_jupyter() {
+    command -v uv &>/dev/null || gpu_pacman_install "uv"
+    if [[ ! -x "${ML_VENV}/bin/python" ]]; then
+        log_info "dusky-ml venv missing; creating a CPU one (run 400 for GPU torch)."
+        mkdir -p "$ML_HOME"
+        uv venv --python-preference only-system "$ML_VENV"
+    fi
+    uv pip install --python "${ML_VENV}/bin/python" jupyterlab ipykernel
+    log_ok "JupyterLab installed in ${ML_VENV}"
+    log_info "Launch: ${ML_VENV}/bin/jupyter lab"
+}
+
+# --- VS Code ---------------------------------------------------------------------------
+install_vscode() {
+    if [[ "$CODE_BIN" -eq 1 ]]; then
+        gpu_aur_install "visual-studio-code-bin"
+    else
+        gpu_pacman_install "code"
+    fi
+    log_ok "VS Code installed."
+    log_info "Recommended extensions: ms-python.python, ms-toolsai.jupyter"
+}
+
+# --- project template ----------------------------------------------------------------------
+install_template() {
+    [[ -d "$TEMPLATE_DIR" ]] && { log_ok "Template already exists at ${TEMPLATE_DIR}."; return; }
+
+    mkdir -p "${TEMPLATE_DIR}/notebooks" "${TEMPLATE_DIR}/src"
+
+    cat >"${TEMPLATE_DIR}/pyproject.toml" <<'EOF'
+[project]
+name = "ml-template"
+version = "0.1.0"
+description = "Dusky ML starter project"
+requires-python = ">=3.11"
+dependencies = [
+    "torch",
+    "transformers",
+    "datasets",
+    "accelerate",
+]
+
+[tool.uv]
+# The dusky ML venv already carries vendor-matched torch; `uv venv` here keeps
+# experiments isolated instead.
+EOF
+
+    cat >"${TEMPLATE_DIR}/.gitignore" <<'EOF'
+.venv/
+__pycache__/
+*.egg-info/
+.ipynb_checkpoints/
+# models & datasets never belong in git
+*.gguf
+*.safetensors
+*.bin
+runs/
+wandb/
+EOF
+
+    cat >"${TEMPLATE_DIR}/README.md" <<'EOF'
+# ml-template
+
+Dusky ML starter. Copy it per experiment: `cp -r ~/Projects/ml-template ~/Projects/my-exp`
+
+- `notebooks/` -- JupyterLab notebooks
+- `src/` -- importable package code
+- system-wide GPU venv: `~/.local/lib/dusky-ml/.venv` (torch matched to your GPU)
+- health check: `dusky-ml-doctor`
+EOF
+
+    cat >"${TEMPLATE_DIR}/notebooks/01_start_here.ipynb" <<'EOF'
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["# Start here\n", "\n", "Kernel: select the `dusky-ml` venv python (`~/.local/lib/dusky-ml/.venv/bin/python`)."]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": ["import torch\n", "print(torch.__version__)\n", "print('cuda:', torch.cuda.is_available())\n", "print('hip:', torch.version.hip)"]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {"display_name": "dusky-ml", "language": "python", "name": "dusky-ml"},
+  "language_info": {"name": "python"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}
+EOF
+
+    touch "${TEMPLATE_DIR}/src/__init__.py"
+    log_ok "Project template created at ${TEMPLATE_DIR}"
+}
+
+# --- main -------------------------------------------------------------------------------------
+main() {
+    log_info "ML notebook lab: JupyterLab (dusky-ml venv) + VS Code + project template."
+    gpu_confirm "  Install the notebook lab?" "$AUTO_MODE" || { log_warn "Skipping."; exit 0; }
+
+    install_jupyter
+    if gpu_confirm "  Install VS Code?" "$AUTO_MODE"; then
+        install_vscode
+    fi
+    install_template
+
+    echo ""
+    log_ok "Notebook lab ready."
+    echo "   Jupyter:     ${ML_VENV}/bin/jupyter lab"
+    echo "   Template:    cp -r ${TEMPLATE_DIR} ~/Projects/<name>"
+}
+
+main "$@"

--- a/user_scripts/arch_setup_scripts/scripts/409_intel_mac_quirks.sh
+++ b/user_scripts/arch_setup_scripts/scripts/409_intel_mac_quirks.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#d: Apply Intel Mac hardware quirks (Wi-Fi, keyboard, sensors)
+
+# -----------------------------------------------------------------------------
+# Script: 409_intel_mac_quirks.sh
+# Purpose: Intel Macs (2012-2020) are ordinary x86_64 PCs -- Arch and dusky
+#          boot on them out of the box -- but three areas want tweaks:
+#
+#            1. Broadcom Wi-Fi (14e4:43xx, common in 2012-2015 models)
+#               -> broadcom-wl-dkms from AUR (wl driver) or b43 for older chips
+#            2. Apple keyboard fn-mode -- /etc/modprobe.d/hid_apple.conf
+#               fnmode=2 makes F1-F12 act as function keys by default
+#            3. lm_sensors + applesmc so `sensors` reports Mac fan/temp data
+#
+#          Registered commented-out in profiles/01_main.toml -- enable it on
+#          Apple hardware. Apple Silicon (M1-M4) is out of scope: it needs
+#          the Asahi/ARM port and has no CUDA/ROCm (see ML_STACK.md).
+#
+# Flags:   --auto      no prompts (still hardware-gated)
+#          --no-wifi   skip the Broadcom driver installation
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+shopt -s nullglob
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/gpu_detect.sh
+source "${SCRIPT_DIR}/lib/gpu_detect.sh"
+
+AUTO_MODE=0
+NO_WIFI=0
+for arg in "$@"; do
+    case "$arg" in
+        --auto)   AUTO_MODE=1 ;;
+        --no-wifi) NO_WIFI=1 ;;
+        *) die "Unknown argument '$arg' (supported: --auto, --no-wifi)" 2 ;;
+    esac
+done
+
+# --- privilege escalation (381 pattern) ---------------------------------------------
+if [[ $EUID -ne 0 ]]; then
+    printf "[\033[0;33mINFO\033[0m] Escalating permissions to root...\n"
+    exec sudo "$0" "$@"
+fi
+
+HID_APPLE_CONF="/etc/modprobe.d/hid_apple.conf"
+
+is_apple_hardware() {
+    local vendor
+    vendor=$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null) || true
+    [[ "$vendor" == "Apple Inc." || "$vendor" == "Apple Computer, Inc." ]]
+}
+
+has_broadcom_wifi() {
+    # Broadcom wireless: vendor 14e4, class 0280 (network controller)
+    command -v lspci &>/dev/null && lspci -d 14e4::0280 2>/dev/null | grep -q .
+}
+
+# --- Broadcom Wi-Fi -------------------------------------------------------------------
+install_broadcom_wifi() {
+    has_broadcom_wifi || { log_info "No Broadcom Wi-Fi detected; skipping."; return; }
+
+    local chip
+    chip=$(lspci -d 14e4::0280 2>/dev/null | head -n1)
+    log_info "Broadcom Wi-Fi found: ${chip}"
+
+    # b43-supported legacy chips (BCM4331 etc.) use linux-firmware, no AUR needed.
+    if grep -qE 'BCM43(31|60)' <<<"$chip"; then
+        log_info "Legacy b43 chip: ensuring linux-firmware is installed."
+        gpu_pacman_install "linux-firmware"
+        log_warn "If Wi-Fi does not appear, check: https://wiki.archlinux.org/title/broadcom_wireless"
+        return
+    fi
+
+    # Everything else (4360/4352/4331 on newer kernels) -> wl driver.
+    # broadcom-wl-dkms moved from AUR into [extra].
+    log_info "Installing broadcom-wl-dkms (needs kernel headers present)."
+    gpu_pacman_install "broadcom-wl-dkms"
+    log_warn "If the wl module blacklists conflict, follow the b43/wl table on the Arch wiki."
+}
+
+# --- Apple keyboard --------------------------------------------------------------------
+configure_hid_apple() {
+    modinfo hid_apple &>/dev/null || { log_info "hid_apple module not present; skipping."; return; }
+
+    if [[ -f "$HID_APPLE_CONF" ]] && grep -q 'fnmode' "$HID_APPLE_CONF"; then
+        log_ok "hid_apple already configured."
+        return
+    fi
+
+    gpu_root_write "$HID_APPLE_CONF" "$(printf '# Managed by dusky 409_intel_mac_quirks.sh\n# F1-F12 behave as function keys; hold Fn for media keys.\noptions hid_apple fnmode=2\n')"
+    log_ok "Wrote ${HID_APPLE_CONF} (fnmode=2)."
+    log_info "Apply immediately for this session:  echo 2 | sudo tee /sys/module/hid_apple/parameters/fnmode"
+
+    # ISO keyboards (EU Macs) may also want iso_layout=0; leave a pointer only.
+    log_info "EU keyboards: add 'options hid_apple iso_layout=0' if ~ and § are swapped."
+}
+
+# --- sensors ------------------------------------------------------------------------------
+install_sensors() {
+    gpu_pacman_install "lm_sensors"
+    if command -v sensors &>/dev/null && ! sensors 2>/dev/null | grep -q applesmc; then
+        log_info "Running sensors-detect so applesmc (fans/temps) gets picked up..."
+        sensors-detect --auto &>/dev/null || log_warn "sensors-detect failed; run it manually."
+    fi
+    if command -v sensors &>/dev/null && sensors 2>/dev/null | grep -q applesmc; then
+        log_ok "applesmc sensors reporting."
+    else
+        log_warn "applesmc not detected (desktop Macs often lack it)."
+    fi
+}
+
+# --- main ------------------------------------------------------------------------------------
+main() {
+    if ! is_apple_hardware; then
+        log_info "Not Apple hardware (DMI vendor: $(cat /sys/class/dmi/id/sys_vendor 2>/dev/null || echo 'unknown')); skipping."
+        exit 0
+    fi
+    log_info "Intel Mac detected."
+    log_info "Scope note: Apple Silicon (M1-M4) needs the Asahi/ARM port -- out of scope."
+    gpu_confirm "  Apply Intel Mac quirks?" "$AUTO_MODE" || { log_warn "Skipping."; exit 0; }
+
+    if [[ "$NO_WIFI" -eq 0 ]]; then
+        install_broadcom_wifi
+    fi
+    configure_hid_apple
+    install_sensors
+
+    echo ""
+    log_ok "Intel Mac quirks applied. Reboot to load Wi-Fi/keyboard changes."
+    log_info "Further reading: https://wiki.archlinux.org/title/Mac"
+}
+
+main "$@"

--- a/user_scripts/arch_setup_scripts/scripts/lib/gpu_detect.sh
+++ b/user_scripts/arch_setup_scripts/scripts/lib/gpu_detect.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# Library: gpu_detect.sh
+# Purpose:  Shared GPU topology detection + install helpers for the dusky
+#           ML/GPU setup scripts (396-402, 409). Source this file; never
+#           execute it directly.
+#
+#           Reuses the detection contract of 380_nvidia_open_source.sh
+#           (sysfs first, strict lspci fallback, virtualization guard) so
+#           every ML script agrees with the driver installer on what
+#           hardware is present.
+#
+# Provides (after gpu_detect_topology):
+#   GPU_HAS_INTEL / GPU_HAS_AMD / GPU_HAS_NVIDIA   (0|1)
+#   GPU_IS_VM                                       (0|1, VirtIO/VMware/VBox)
+#   GPU_PRIMARY_VENDOR                              ("nvidia"|"amd"|"intel"|"vm"|"")
+#
+# Optional probes (call individually):
+#   gpu_nvidia_driver_major    -> echoes driver major (580) or nothing
+#   gpu_rocm_release           -> echoes "6.4" from /opt/rocm or nothing
+#   gpu_rocm_gfx               -> echoes gfx target (gfx1101) or nothing
+#   gpu_hsa_override_for_gfx   -> echoes override ("11.0.0") or nothing
+# -----------------------------------------------------------------------------
+
+# Guard: this is a library, not an entry point.
+[[ "${BASH_SOURCE[0]}" != "$0" ]] || { echo "gpu_detect.sh is a library; source it from a setup script." >&2; exit 1; }
+
+# --- Logging (define only if the caller has not brought its own) -------------
+if ! command -v log_info &>/dev/null; then
+    log_info() { printf "[\033[1;34mINFO\033[0m] %s\n" "$*"; }
+    log_ok()   { printf "[\033[1;32m OK \033[0m] %s\n" "$*"; }
+    log_warn() { printf "[\033[0;33mWARN\033[0m] %s\n" "$*" >&2; }
+    log_err()  { printf "[\033[1;31mERR \033[0m] %s\n" "$*" >&2; }
+    die()      { log_err "$1"; exit "${2:-1}"; }
+fi
+
+# --- Topology detection -------------------------------------------------------
+GPU_HAS_INTEL=0
+GPU_HAS_AMD=0
+GPU_HAS_NVIDIA=0
+GPU_IS_VM=0
+GPU_PRIMARY_VENDOR=""
+
+gpu_detect_topology() {
+    local vendor_id
+
+    # Phase 1: sysfs (preferred -- active GPUs)
+    local card_path
+    for card_path in /sys/class/drm/card[0-9]*; do
+        [[ -r "$card_path/device/vendor" ]] || continue
+        vendor_id=$(<"$card_path/device/vendor")
+        vendor_id=${vendor_id,,}
+        case "$vendor_id" in
+            "0x8086") GPU_HAS_INTEL=1 ;;
+            "0x1002") GPU_HAS_AMD=1 ;;
+            "0x10de") GPU_HAS_NVIDIA=1 ;;
+        esac
+    done
+
+    # Phase 2: lspci fallback (VGA 0300 / 3D 0302 / Display 0380)
+    if command -v lspci &>/dev/null; then
+        [[ "$GPU_HAS_INTEL" -eq 0 ]]  && { lspci -n -d 8086::0300; lspci -n -d 8086::0380; } 2>/dev/null | grep -q . && GPU_HAS_INTEL=1
+        [[ "$GPU_HAS_AMD" -eq 0 ]]    && { lspci -n -d 1002::0300; lspci -n -d 1002::0380; } 2>/dev/null | grep -q . && GPU_HAS_AMD=1
+        [[ "$GPU_HAS_NVIDIA" -eq 0 ]] && { lspci -n -d 10de::0300; lspci -n -d 10de::0302; } 2>/dev/null | grep -q . && GPU_HAS_NVIDIA=1
+    fi
+
+    # Phase 3: virtualization guard (VirtIO 1af4 / VMware 15ad / VirtualBox 80ee)
+    if [[ $((GPU_HAS_INTEL + GPU_HAS_AMD + GPU_HAS_NVIDIA)) -eq 0 ]]; then
+        if command -v lspci &>/dev/null && { lspci -d 1af4::0300; lspci -d 15ad::0300; lspci -d 80ee::0300; } 2>/dev/null | grep -q .; then
+            GPU_IS_VM=1
+            GPU_PRIMARY_VENDOR="vm"
+        fi
+    fi
+
+    # Primary vendor for ML backend choice: NVIDIA > AMD > Intel.
+    if [[ "$GPU_HAS_NVIDIA" -eq 1 ]]; then
+        GPU_PRIMARY_VENDOR="nvidia"
+    elif [[ "$GPU_HAS_AMD" -eq 1 ]]; then
+        GPU_PRIMARY_VENDOR="amd"
+    elif [[ "$GPU_HAS_INTEL" -eq 1 ]]; then
+        GPU_PRIMARY_VENDOR="intel"
+    fi
+    # These five are the library's public outputs, consumed by the sourcing
+    # setup scripts (396-402, 409); referenced here so shellcheck sees the use.
+    : "${GPU_HAS_INTEL}" "${GPU_HAS_AMD}" "${GPU_HAS_NVIDIA}" "${GPU_IS_VM}" "${GPU_PRIMARY_VENDOR}"
+}
+
+# --- NVIDIA runtime probes -----------------------------------------------------
+
+# Echoes the loaded driver major version (e.g. 580), or nothing when the
+# proprietary driver is absent/not talking. Never fails.
+gpu_nvidia_driver_major() {
+    local ver
+    ver=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null | head -n1 | cut -d. -f1) || true
+    [[ "$ver" =~ ^[0-9]+$ ]] && echo "$ver" || true
+}
+
+# --- AMD ROCm runtime probes ---------------------------------------------------
+
+# Echoes the installed ROCm release ("6.4"), or nothing.
+gpu_rocm_release() {
+    local ver
+    ver=$(cut -d. -f1,2 /opt/rocm/.info/version 2>/dev/null | tr -dc '0-9.') || true
+    [[ -n "$ver" ]] && echo "$ver" || true
+}
+
+# Echoes the first gfx target reported by rocminfo (e.g. gfx1101), or nothing.
+gpu_rocm_gfx() {
+    local gfx
+    gfx=$(rocminfo 2>/dev/null | grep -m1 -oE 'gfx[0-9a-f]+') || true
+    [[ -n "$gfx" ]] && echo "$gfx" || true
+}
+
+# Maps consumer gfx targets that lack native MIOpen/rocBLAS kernels onto the
+# nearest supported architecture. Mirrors the mapping proven by the Kokoro
+# TTS installer (user_scripts/tts_stt/dusky_kokoro/kokoro_installer.sh).
+gpu_hsa_override_for_gfx() {
+    local gfx="${1:-}"
+    case "$gfx" in
+        gfx1031|gfx1032|gfx1033|gfx1034|gfx1035|gfx1036) echo "10.3.0" ;;
+        gfx1010|gfx1011|gfx1012)                          echo "10.3.0" ;;
+        gfx1101|gfx1102|gfx1103)                          echo "11.0.0" ;;
+        *)                                                 true ;;
+    esac
+}
+
+# True (0) when a usable ROCm userspace exists on this machine.
+gpu_rocm_available() {
+    [[ -d /opt/rocm ]] || command -v rocm-smi &>/dev/null || [[ -e /dev/kfd ]]
+}
+
+# --- Install / write helpers ----------------------------------------------------
+
+# y/N prompt honouring --auto: auto=1 accepts, auto=0 asks.
+gpu_confirm() {
+    local prompt="$1" auto="${2:-0}"
+    [[ "$auto" -eq 1 ]] && return 0
+    local choice
+    read -rp "$prompt [y/N] " choice || true
+    [[ "${choice:-N}" =~ ^[yY] ]]
+}
+
+# Atomic write for files the current user owns (temp + fsync + rename).
+gpu_atomic_write() {
+    local file="$1" content="$2" tmp
+    tmp=$(mktemp "${file}.XXXXXX") || return 1
+    printf '%s' "$content" >"$tmp" || { rm -f "$tmp"; return 1; }
+    sync "$tmp" 2>/dev/null || true
+    mv -f "$tmp" "$file"
+}
+
+# Root-owned atomic write (self-escalating, safe under `set -e`). Uses plain
+# sudo (not -n): this runs from attended installers where a password prompt
+# is fine, whereas `sudo -n` would hard-fail under `set -e` the moment sudo
+# wants a password.
+gpu_root_write() {
+    local file="$1" content="$2" tmp
+    tmp=$(mktemp) || return 1
+    printf '%s' "$content" >"$tmp" || { rm -f "$tmp"; return 1; }
+    if [[ $EUID -eq 0 ]]; then
+        install -D -m 0644 "$tmp" "$file"; local rc=$?
+    else
+        sudo install -D -m 0644 "$tmp" "$file"; local rc=$?
+    fi
+    rm -f "$tmp"
+    return "$rc"
+}
+
+# pacman wrapper: skips cleanly when pacman is missing (non-Arch CI).
+gpu_pacman_install() {
+    command -v pacman &>/dev/null || { log_warn "pacman not found; skipping: $*"; return 0; }
+    if [[ $EUID -eq 0 ]]; then
+        pacman -S --needed --noconfirm "$@"
+    else
+        sudo pacman -S --needed --noconfirm "$@"
+    fi
+}
+
+# paru wrapper for AUR packages. MUST run as the invoking user (paru refuses
+# root); when elevated, de-escalates through SUDO_USER. Skips when paru is
+# absent so ML scripts stay optional rather than fatal.
+gpu_aur_install() {
+    # Flags verified against a real paru binary: --needed/--noconfirm come
+    # from pacman, --noredownload is paru's (skip source re-download).
+    local paru_cmd=(paru -S --needed --noconfirm --noredownload)
+    if ! command -v paru &>/dev/null; then
+        log_warn "paru not found; skipping AUR packages: $*"
+        log_warn "install them manually once paru is available."
+        return 0
+    fi
+    if [[ $EUID -eq 0 && -n "${SUDO_USER:-}" ]]; then
+        sudo -u "$SUDO_USER" "${paru_cmd[@]}" "$@"
+    else
+        "${paru_cmd[@]}" "$@"
+    fi
+}

--- a/user_scripts/llm/llama_server/README.md
+++ b/user_scripts/llm/llama_server/README.md
@@ -1,0 +1,42 @@
+# dusky llama-server
+
+OpenAI-compatible local inference server backed by [llama.cpp](https://github.com/ggml-org/llama.cpp),
+installed by `user_scripts/arch_setup_scripts/scripts/399_ml_runtimes.sh`.
+
+## What runs where
+
+| Piece | Path |
+|---|---|
+| systemd user unit | `~/.config/systemd/user/llama-server.service` |
+| options file | `~/.config/dusky/llama_server/llama-server.env` |
+| model directory | `~/.local/share/dusky-llama/models` |
+| endpoint | `http://127.0.0.1:8081/v1` |
+
+## Usage
+
+```bash
+# drop a GGUF into the model dir (any Hugging Face GGUF repo works)
+mkdir -p ~/.local/share/dusky-llama/models
+
+# point the server at it (edit and restart)
+$EDITOR ~/.config/dusky/llama_server/llama-server.env
+systemctl --user start llama-server
+
+curl http://127.0.0.1:8081/v1/chat/completions \
+  -d '{"model":"local","messages":[{"role":"user","content":"hello dusky"}]}'
+```
+
+The unit is deliberately **not** enabled at install time: an idle inference
+server still pins VRAM. Enable it with `systemctl --user enable llama-server`
+if you want it at every login.
+
+## GPU acceleration
+
+`399_ml_runtimes.sh` installs the vendor-matched build automatically:
+
+- NVIDIA → `llama-cpp` + `ggml-cuda` (extra) — CUDA
+- AMD → `llama-cpp` + `ggml-hip` (extra, needs `396_amd_rocm_stack.sh`) — ROCm/HIP
+- otherwise → `llama-cpp` + `ggml-vulkan` (extra) — Vulkan
+
+`--n-gpu-layers 999` in `LLAMA_ARGS` offloads all layers to the GPU; remove it
+to fall back to CPU.

--- a/user_scripts/llm/llama_server/llama-server.env
+++ b/user_scripts/llm/llama_server/llama-server.env
@@ -1,0 +1,10 @@
+# llama-server.env -- options for the dusky llama-server user service.
+#
+# Installed by 399_ml_runtimes.sh; edit freely, then:
+#   systemctl --user restart llama-server
+#
+# LLAMA_ARGS is passed verbatim to llama-server (see `llama-server --help`).
+# Put GGUF models under ~/.local/share/dusky-llama/models and point --model
+# at one, e.g.:
+#   LLAMA_ARGS=--model /home/you/.local/share/dusky-llama/models/qwen2.5-7b-instruct-q4_k_m.gguf --ctx-size 8192 --n-gpu-layers 999
+LLAMA_ARGS=

--- a/user_scripts/llm/llama_server/llama-server.service
+++ b/user_scripts/llm/llama_server/llama-server.service
@@ -1,0 +1,31 @@
+# ~/.config/systemd/user/llama-server.service
+#
+# OpenAI-compatible local inference server backed by llama.cpp.
+# Installed by 399_ml_runtimes.sh; NOT auto-started (an inference server
+# pins VRAM while idle -- start it when you need it):
+#
+#   systemctl --user start   llama-server
+#   systemctl --user enable  llama-server     # autostart at login
+#
+#   endpoint: http://127.0.0.1:8081/v1
+#
+# Model and server options live in the EnvironmentFile written next to this
+# unit at install time (~/.config/dusky/llama_server/llama-server.env).
+[Unit]
+Description=Dusky llama.cpp server (OpenAI-compatible API on 127.0.0.1:8081)
+Documentation=https://github.com/ggml-org/llama.cpp
+PartOf=graphical-session.target
+After=graphical-session.target
+
+[Service]
+Type=simple
+# sh -c is required: systemd does not expand $LLAMA_ARGS in ExecStart.
+ExecStart=/bin/sh -c 'exec /usr/bin/llama-server --host 127.0.0.1 --port 8081 $LLAMA_ARGS'
+EnvironmentFile=%h/.config/dusky/llama_server/llama-server.env
+Restart=on-failure
+RestartSec=2
+# GPU access (/dev/nvidia*, /dev/kfd, /dev/dri) lives in the user session.
+NoNewPrivileges=yes
+
+[Install]
+WantedBy=default.target

--- a/user_scripts/llm/llm_side_panal/auto_config.sh
+++ b/user_scripts/llm/llm_side_panal/auto_config.sh
@@ -36,7 +36,16 @@ log_ok "Systemd user service enabled."
 
 # 2. Check Dependencies & Ollama
 if ! command -v ollama &>/dev/null; then
-    log_warn "Ollama binary is not installed yet. You can install it via: sudo pacman -S ollama"
+    # Vendor-matched variant so inference lands on the GPU
+    # (installed properly by 399_ml_runtimes.sh; this is the fallback hint).
+    OLLAMA_PKG="ollama"
+    if command -v nvidia-smi &>/dev/null && nvidia-smi &>/dev/null; then
+        OLLAMA_PKG="ollama-cuda"
+    elif [[ -e /dev/kfd ]]; then
+        OLLAMA_PKG="ollama-rocm"
+    fi
+    log_warn "Ollama binary is not installed yet."
+    log_warn "GPU-matched install: sudo pacman -S ${OLLAMA_PKG}   (or run 399_ml_runtimes.sh)"
 else
     log_info "Ollama binary detected."
     if ! systemctl is-active --quiet ollama.service 2>/dev/null; then

--- a/user_scripts/llm/ml_stack/dusky_ml_doctor.py
+++ b/user_scripts/llm/ml_stack/dusky_ml_doctor.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+#d: Diagnose the dusky ML stack (GPU, runtimes, services)
+
+"""dusky-ml-doctor -- one-shot health check for the dusky ML/GPU stack.
+
+Installed into ~/.local/bin by 400_ml_training_stack.sh; run with the dusky-ml
+venv python to also probe PyTorch:
+
+    ~/.local/lib/dusky-ml/.venv/bin/python ~/.local/bin/dusky-ml-doctor
+
+Checks (each independent, failures never abort the report):
+  * torch      -- installed? CUDA (name, VRAM) or ROCm/HIP visible?
+  * onnxruntime -- execution providers available
+  * ollama     -- service state + API reachability
+  * llama.cpp  -- llama-server binary + user unit
+  * disk       -- footprint of ~/.local/lib/dusky-ml
+Exit code is always 0; the report is the point.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+
+GREEN, YELLOW, RED, BOLD, RESET = "\033[32m", "\033[33m", "\033[31m", "\033[1m", "\033[0m"
+ML_HOME = Path.home() / ".local" / "lib" / "dusky-ml"
+
+
+def ok(msg: str) -> None:
+    print(f"  {GREEN}ok{RESET}   {msg}")
+
+
+def warn(msg: str) -> None:
+    print(f"  {YELLOW}warn{RESET} {msg}")
+
+
+def bad(msg: str) -> None:
+    print(f"  {RED}fail{RESET} {msg}")
+
+
+def section(name: str) -> None:
+    print(f"\n{BOLD}:: {name}{RESET}")
+
+
+def check_torch() -> None:
+    section("PyTorch")
+    try:
+        import torch  # type: ignore
+    except Exception:
+        bad("not installed in this interpreter (run 400_ml_training_stack.sh)")
+        return
+    ok(f"torch {torch.__version__}")
+    if getattr(torch, "cuda", None) and torch.cuda.is_available():
+        for i in range(torch.cuda.device_count()):
+            props = torch.cuda.get_device_properties(i)
+            total_gib = props.total_memory / 1024**3
+            ok(f"CUDA device {i}: {props.name} ({total_gib:.1f} GiB, capability {props.major}.{props.minor})")
+    elif torch.version.hip:
+        warn("ROCm build detected but no device usable -- check 'rocminfo' and the render group")
+        gfx = os.environ.get("HSA_OVERRIDE_GFX_VERSION", "")
+        warn(f"HIP {torch.version.hip}; HSA_OVERRIDE_GFX_VERSION={gfx or 'unset'}")
+    elif torch.cuda.is_available() is False and torch.version.cuda:
+        warn("CUDA build but driver reports no device -- is nvidia-smi happy?")
+    else:
+        warn("CPU-only torch (no CUDA device, no HIP)")
+
+
+def check_onnxruntime() -> None:
+    section("onnxruntime")
+    try:
+        import onnxruntime as ort  # type: ignore
+    except Exception:
+        bad("not installed in this interpreter")
+        return
+    providers = ort.get_available_providers()
+    ok(f"providers: {', '.join(providers)}")
+    gpu_eps = [p for p in providers if p not in ("CPUExecutionProvider",)]
+    if not gpu_eps:
+        warn("CPUExecutionProvider only -- GPU EP absent")
+
+
+def service_state(unit: str, user: bool = True) -> str:
+    cmd = ["systemctl", *(["--user"] if user else []), "is-active", unit]
+    try:
+        res = subprocess.run(cmd, capture_output=True, text=True, timeout=5)
+        return res.stdout.strip() or "unknown"
+    except Exception:
+        return "unknown"
+
+
+def check_ollama() -> None:
+    section("Ollama")
+    if not shutil.which("ollama"):
+        bad("ollama binary not found (run 399_ml_runtimes.sh)")
+        return
+    variant = "ollama"
+    for pkg in ("ollama-cuda", "ollama-rocm", "ollama"):
+        try:
+            subprocess.run(["pacman", "-Qq", pkg], capture_output=True, timeout=5, check=True)
+            variant = pkg
+            break
+        except Exception:
+            continue
+    ok(f"binary present (package: {variant})")
+    state = service_state("ollama.service", user=False)
+    (ok if state == "active" else warn)(f"system ollama.service: {state}")
+    if state != "active":
+        state = service_state("ollama.service", user=True)
+        (ok if state == "active" else warn)(f"user ollama.service: {state}")
+    try:
+        with urllib.request.urlopen("http://127.0.0.1:11434/api/tags", timeout=3) as resp:
+            models = [m.get("name") for m in json.loads(resp.read()).get("models", [])]
+        ok(f"API reachable; models: {', '.join(models) if models else '(none pulled yet)'}")
+    except Exception:
+        warn("API not reachable on 127.0.0.1:11434")
+
+
+def check_llama_cpp() -> None:
+    section("llama.cpp")
+    llama_server = shutil.which("llama-server")
+    if llama_server:
+        ok(f"llama-server at {llama_server}")
+    else:
+        bad("llama-server not on PATH (run 399_ml_runtimes.sh)")
+        return
+    state = service_state("llama-server.service")
+    (ok if state == "active" else warn)(f"user llama-server.service: {state} (start: systemctl --user start llama-server)")
+
+
+def check_disk() -> None:
+    section("disk footprint")
+    if not ML_HOME.exists():
+        warn(f"{ML_HOME} does not exist (training stack not provisioned)")
+        return
+
+    def du(path: Path) -> int:
+        total = 0
+        for f in path.rglob("*"):
+            try:
+                if f.is_file():
+                    total += f.stat().st_size
+            except OSError:
+                pass
+        return total
+
+    gib = du(ML_HOME) / 1024**3
+    ok(f"{ML_HOME}: {gib:.1f} GiB total")
+
+
+def main() -> None:
+    print(f"{BOLD}dusky-ml-doctor{RESET} -- ML stack health check")
+    print(f"  interpreter: {sys.version.split()[0]} ({sys.executable})")
+    check_torch()
+    check_onnxruntime()
+    check_ollama()
+    check_llama_cpp()
+    check_disk()
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/user_scripts/tts_stt/dusky_parakeet/dusky_installer.py
+++ b/user_scripts/tts_stt/dusky_parakeet/dusky_installer.py
@@ -6,15 +6,19 @@ Hardware is explicit and auto-detected -- no hardcoded users or machines:
 
   --hardware auto    (default) detect nvidia > amd > cpu
   --hardware nvidia  NVIDIA dGPU via onnxruntime-gpu + CUDA 13 (D3cold capable)
-  --hardware amd     AMD GPU present; ASR runs on CPU reliably, tries
-                     MIGraphX/ROCM EPs opportunistically if installed
+  --hardware amd     AMD GPU via Arch's python-onnxruntime-rocm ([extra],
+                     exposed through a system-site-packages worker venv)
+                     when a usable ROCm stack is present (see detect_rocm);
+                     otherwise CPU onnxruntime (reliable fallback)
   --hardware cpu     CPU-only, always works
 
 Layout (username-agnostic, all under $HOME):
   APP_DIR = ~/.local/lib/dusky-stt
     .venv-main    CPU onnxruntime + numpy + sounddevice (daemon, never CUDA)
     .venv-worker  nvidia: onnxruntime-gpu + CUDA 13 + onnx-asr --no-deps
-                  cpu/amd: onnxruntime + onnx-asr (CPU, always works)
+                  amd+ROCm: system onnxruntime-rocm via --system-site-packages
+                            + onnx-asr --no-deps
+                  cpu/amd (no ROCm): onnxruntime + onnx-asr (CPU, always works)
 """
 
 import argparse
@@ -81,6 +85,31 @@ WORKER_CUDA_PACKAGES = (
 WORKER_NVIDIA_PACKAGES = ("onnxruntime-gpu==1.29.0", "numpy==2.5.2", "huggingface-hub>=0.34")
 WORKER_NVIDIA_NO_DEPS = ("onnx-asr==0.12.0",)
 WORKER_CPU_PACKAGES = ("onnxruntime==1.29.0", "numpy==2.5.2", "huggingface-hub>=0.34", "onnx-asr==0.12.0")
+
+# AMD path: Arch's own python-onnxruntime-rocm from [extra], exposed to the
+# worker through a --system-site-packages venv -- the same source Kokoro TTS
+# calls "--rocm-source arch". AMD's flat wheel index (repo.radeon.com) was
+# audited and deliberately NOT used: it stops at ROCm 7.0 / cp312 wheels
+# while Arch ships ROCm 7.2 / CPython 3.14, so it cannot serve current
+# systems. The [extra] package is built against exactly Arch's python and
+# ROCm, and this installer always builds venvs from sys.executable, so the
+# interpreters match by construction.
+ROCM_SYSTEM_PACKAGE = "python-onnxruntime-rocm"
+# onnx-asr must be --no-deps here too: its metadata would pull plain
+# onnxruntime (CPU) next to the system onnxruntime-rocm and collide on the
+# onnxruntime/ package directory.
+WORKER_ROCM_VENV_PKGS = ("numpy>=2.3", "huggingface-hub>=0.34")
+WORKER_ROCM_NO_DEPS = ("onnx-asr==0.12.0",)
+
+# Consumer gfx targets without native MIOpen/rocBLAS kernels map onto the
+# nearest supported architecture (same table as Kokoro TTS /
+# scripts/lib/gpu_detect.sh).
+HSA_OVERRIDE_MAP = {
+    "gfx1031": "10.3.0", "gfx1032": "10.3.0", "gfx1033": "10.3.0",
+    "gfx1034": "10.3.0", "gfx1035": "10.3.0", "gfx1036": "10.3.0",
+    "gfx1010": "10.3.0", "gfx1011": "10.3.0", "gfx1012": "10.3.0",
+    "gfx1101": "11.0.0", "gfx1102": "11.0.0", "gfx1103": "11.0.0",
+}
 
 SILERO_TAG = "v6.2.1"
 SILERO_URL = f"https://raw.githubusercontent.com/snakers4/silero-vad/{SILERO_TAG}/src/silero_vad/data/silero_vad.onnx"
@@ -182,6 +211,32 @@ def detect_hardware() -> tuple[str, JsonObject]:
     return "cpu", {}
 
 
+def detect_rocm() -> JsonObject | None:
+    """Probe a usable ROCm userspace for the amd worker path.
+
+    Returns {"release", "gfx", "hsa_override"} or None when ROCm is absent or
+    cannot run (no KFD). Mirrors the Kokoro TTS installer's contract.
+    """
+    version_file = Path("/opt/rocm/.info/version")
+    if not Path("/dev/kfd").exists():
+        return None  # amdgpu KFD node missing -> ROCm cannot execute
+    if not version_file.exists() and not shutil.which("rocm-smi"):
+        return None
+    release = ""
+    if version_file.exists():
+        try:
+            release = ".".join(version_file.read_text(encoding="utf-8").strip().split(".")[:2])
+        except OSError:
+            pass
+    gfx = ""
+    rocminfo = shutil.which("rocminfo")
+    if rocminfo:
+        res = run([rocminfo], timeout=60, check=False)
+        match = re.search(r"gfx[0-9a-f]+", res.stdout or "")
+        gfx = match.group(0) if match else ""
+    return {"release": release, "gfx": gfx, "hsa_override": HSA_OVERRIDE_MAP.get(gfx, "")}
+
+
 def query_nvidia_gpu(gpu_device: int) -> tuple[int, str]:
     """Return (total_mib, driver) for the requested NVIDIA index. Raises if missing."""
     smi = shutil.which("nvidia-smi")
@@ -271,7 +326,8 @@ def install_pacman_packages(packages: tuple[str, ...], skip: bool) -> None:
 
 
 # ------------------------------------------------------------------ venvs
-def install_python_environments(stage: Path, hardware: str) -> tuple[Path, Path]:
+def install_python_environments(stage: Path, hardware: str, worker_ort: str,
+                                rocm: JsonObject | None) -> tuple[Path, Path]:
     log_step(f"Provisioning venvs via uv (hardware={hardware})")
     uv = shutil.which("uv")
     if not uv:
@@ -291,28 +347,53 @@ def install_python_environments(stage: Path, hardware: str) -> tuple[Path, Path]
     worker_venv = stage / ".venv-worker"
     log_step("Creating .venv-main + .venv-worker")
     run([uv, "venv", "--python", sys.executable, "--python-preference", "only-system", str(main_venv)], env=env)
-    run([uv, "venv", "--python", sys.executable, "--python-preference", "only-system", str(worker_venv)], env=env)
+    # The rocm worker sees the system python-onnxruntime-rocm through
+    # system-site-packages; every other worker is fully isolated.
+    worker_ssp = ["--system-site-packages"] if worker_ort == "rocm" else []
+    run([uv, "venv", "--python", sys.executable, "--python-preference", "only-system", *worker_ssp, str(worker_venv)], env=env)
     main_py = main_venv / "bin" / "python"
     worker_py = worker_venv / "bin" / "python"
     log_step("Installing .venv-main packages (onnxruntime CPU, ~50 MiB)")
     run([uv, "pip", "install", "--python", str(main_py), *MAIN_PACKAGES], env=env, quiet=False, timeout=1800)
-    if hardware == "nvidia":
+    if worker_ort == "cuda":
         log_step("Installing CUDA 13 runtime wheels (~2.2 GiB -- expect several minutes, progress below)")
         run([uv, "pip", "install", "--python", str(worker_py), *WORKER_CUDA_PACKAGES], env=env, quiet=False, timeout=3600)
         log_step("Installing onnxruntime-gpu + deps")
         run([uv, "pip", "install", "--python", str(worker_py), *WORKER_NVIDIA_PACKAGES], env=env, quiet=False, timeout=1800)
         log_step("Installing onnx-asr --no-deps (protects CUDA namespace)")
         run([uv, "pip", "install", "--python", str(worker_py), "--no-deps", *WORKER_NVIDIA_NO_DEPS], env=env, quiet=False, timeout=600)
+    elif worker_ort == "rocm":
+        # onnxruntime-rocm itself comes from the system package; only the
+        # helper deps are installed into the venv.
+        if subprocess.run(["pacman", "-Qq", ROCM_SYSTEM_PACKAGE], capture_output=True).returncode != 0:
+            raise InstallError(
+                f"{ROCM_SYSTEM_PACKAGE} is not installed. The amd/ROCm worker reads it "
+                "through system-site-packages; install it with "
+                "'sudo pacman -S python-onnxruntime-rocm' (or 396_amd_rocm_stack.sh --python), "
+                "or re-run with --hardware cpu for the reliable CPU path.")
+        release = (rocm or {}).get("release", "")
+        log_step(f"Worker uses system {ROCM_SYSTEM_PACKAGE} (ROCm {release or '?'}) via system-site-packages")
+        log_step("Installing worker helper deps (numpy, huggingface-hub)")
+        run([uv, "pip", "install", "--python", str(worker_py), *WORKER_ROCM_VENV_PKGS], env=env, quiet=False, timeout=1800)
+        log_step("Installing onnx-asr --no-deps (protects the ROCm namespace)")
+        run([uv, "pip", "install", "--python", str(worker_py), "--no-deps", *WORKER_ROCM_NO_DEPS], env=env, quiet=False, timeout=600)
     else:
         log_step(f"Installing worker packages ({hardware}, CPU ORT)")
         run([uv, "pip", "install", "--python", str(worker_py), *WORKER_CPU_PACKAGES], env=env, quiet=False, timeout=1800)
     run([uv, "pip", "check", "--python", str(main_py)], env=env)
-    run([uv, "pip", "check", "--python", str(worker_py)], env=env)
+    # A system-site-packages venv also sees system dists, whose dependency
+    # state pacman (not pip) owns -- treat pip check as advisory there.
+    if worker_ort == "rocm":
+        res = run([uv, "pip", "check", "--python", str(worker_py)], env=env, check=False)
+        if res.returncode != 0 and (res.stdout or "").strip():
+            log_warn(f"uv pip check reported (system packages included): {(res.stdout or '').strip()[:300]}")
+    else:
+        run([uv, "pip", "check", "--python", str(worker_py)], env=env)
     log_ok("Virtual environments built.")
     return main_py, worker_py
 
 
-def verify_namespaces(main_py: Path, worker_py: Path, hardware: str) -> None:
+def verify_namespaces(main_py: Path, worker_py: Path, worker_ort: str) -> None:
     log_step("Asserting onnxruntime namespace exclusivity")
     probe = (
         "import importlib.metadata as m, sys; "
@@ -320,9 +401,14 @@ def verify_namespaces(main_py: Path, worker_py: Path, hardware: str) -> None:
         "assert owners == [sys.argv[1]], f'Namespace collision: {owners}'"
     )
     run([str(main_py), "-c", probe, "onnxruntime"], env={"CUDA_VISIBLE_DEVICES": "-1"})
-    expected = "onnxruntime-gpu" if hardware == "nvidia" else "onnxruntime"
+    # NOTE on the rocm path: Arch's python-onnxruntime-rocm package carries a
+    # distribution literally named "onnxruntime" (verified against its
+    # dist-info), so the probe expects the same name as the cpu path. The
+    # functional cpu/rocm distinction is the worker self-test's provider
+    # check, not this name.
+    expected = "onnxruntime-gpu" if worker_ort == "cuda" else "onnxruntime"
     run([str(worker_py), "-c", probe, expected],
-        env={"CUDA_VISIBLE_DEVICES": "0" if hardware == "nvidia" else "-1"})
+        env={"CUDA_VISIBLE_DEVICES": "0" if worker_ort == "cuda" else "-1"})
     log_ok("ORT namespaces partitioned.")
 
 
@@ -438,7 +524,8 @@ for f in ('libcuda.so', 'libcudart.so', 'libcublas', 'libcudnn', 'onnxruntime_pr
     log_ok("CPU VAD clean.")
 
 
-def verify_worker(worker_py: Path, stage: Path, hardware: str, gpu_device: int, config_path: Path) -> JsonObject:
+def verify_worker(worker_py: Path, stage: Path, hardware: str, gpu_device: int, config_path: Path,
+                  worker_ort: str = "cpu", hsa_override: str = "") -> JsonObject:
     log_step(f"Self-testing worker (hardware={hardware}) -- ~30-60s, silent while encoder loads")
     env = dict(os.environ)
     if hardware == "nvidia":
@@ -447,6 +534,10 @@ def verify_worker(worker_py: Path, stage: Path, hardware: str, gpu_device: int, 
         env["CUDA_MODULE_LOADING"] = "LAZY"
     else:
         env["CUDA_VISIBLE_DEVICES"] = "-1"
+    if hsa_override:
+        # Consumer gfx without native MIOpen/rocBLAS kernels must be mapped
+        # before libamdhip64 initializes (same contract as Kokoro TTS).
+        env["HSA_OVERRIDE_GFX_VERSION"] = hsa_override
     env["HF_HUB_OFFLINE"] = "1"
     res = run([str(worker_py), str(stage / "dusky_worker.py"), "--config", str(config_path), "--self-test"],
               env=env, cwd=stage, timeout=600, quiet=True)
@@ -457,6 +548,14 @@ def verify_worker(worker_py: Path, stage: Path, hardware: str, gpu_device: int, 
         report = {"ok": True, "raw": stdout[-500:]}
     if hardware == "nvidia" and not report.get("ok"):
         raise InstallError(f"CUDA self-test failed (no CUDA EP nodes): {report}")
+    if worker_ort == "rocm":
+        providers = [p for ps in (report.get("providers") or [])
+                     for p in (ps if isinstance(ps, list) else [])]
+        if not any(("ROCmExecutionProvider" in p) or ("MIGraphXExecutionProvider" in p) for p in providers):
+            raise InstallError(
+                "ROCm self-test failed: no ROCm/MIGraphX EP in session providers "
+                f"({providers}). The wheels linked but the runtime did not bind -- "
+                "check 'rocminfo' and the render group, or re-run with --hardware cpu.")
     log_ok(f"Worker self-test passed ({hardware}).")
     return report
 
@@ -478,7 +577,7 @@ def deploy_stage(stage: Path) -> Path | None:
     return backup
 
 
-def install_entrypoints() -> None:
+def install_entrypoints(hsa_override: str = "") -> None:
     log_step("Installing entry points and unit")
     BIN_DIR.mkdir(parents=True, exist_ok=True)
     UNIT_DIR.mkdir(parents=True, exist_ok=True)
@@ -494,6 +593,17 @@ def install_entrypoints() -> None:
     os.chmod(verify_dest, 0o755)
     unit_dest = UNIT_DIR / UNIT_NAME
     shutil.copyfile(APP_DIR / UNIT_NAME, unit_dest)
+    if hsa_override:
+        # Same mapping the self-test needed; the deployed service must set it
+        # before the worker imports libamdhip64.
+        unit_text = unit_dest.read_text(encoding="utf-8")
+        if "HSA_OVERRIDE_GFX_VERSION" not in unit_text and "[Service]" in unit_text:
+            unit_text = unit_text.replace(
+                "[Service]\n",
+                f"[Service]\n# Consumer gfx without native MIOpen/rocBLAS kernels (set by installer)\n"
+                f"Environment=HSA_OVERRIDE_GFX_VERSION={hsa_override}\n", 1)
+            unit_dest.write_text(unit_text, encoding="utf-8")
+            log_ok(f"HSA_OVERRIDE_GFX_VERSION={hsa_override} baked into {UNIT_NAME}")
     os.chmod(unit_dest, 0o644)
     run(["systemd-analyze", "--user", "verify", str(unit_dest)])
     run(["systemctl", "--user", "daemon-reload"])
@@ -546,7 +656,10 @@ def main(argv: list[str]) -> int:
     log_step(f"Hardware backend: {hardware} (auto-detected: {detected})")
 
     gpu_limit = 4096
+    worker_ort = "cpu"
+    rocm: JsonObject | None = None
     if hardware == "nvidia":
+        worker_ort = "cuda"
         total_mb, _driver = query_nvidia_gpu(args.gpu_device)
         # 2GB-VRAM guard: fp32 encoder alone is ~2.5 GB and can never fit;
         # fail fast with a clear message instead of a post-download OOM.
@@ -559,13 +672,22 @@ def main(argv: list[str]) -> int:
                      "context + activations): tight. Prefer --quantization int8.")
         gpu_limit = choose_vram_limit(total_mb, args.gpu_mem_limit_mb)
     elif hardware == "amd":
-        log_warn("AMD GPU acceleration via MIGraphX/ROCm is opportunistic; CPU fallback always works. "
-                 "For GPU EP install ROCm + MIGraphX system-side; otherwise CPU is used.")
+        rocm = detect_rocm()
+        if rocm:
+            worker_ort = "rocm"
+            note = f", HSA_OVERRIDE_GFX_VERSION={rocm['hsa_override']}" if rocm["hsa_override"] else ""
+            log_step(f"AMD ROCm path: release {rocm['release'] or '?'}, gfx {rocm['gfx'] or 'unknown'}{note}")
+            log_warn("python-onnxruntime-rocm pulls the full rocm-hip-sdk dependency chain (~30 GiB installed).")
+        else:
+            log_warn("AMD GPU present but no usable ROCm stack (/opt/rocm + /dev/kfd).")
+            log_warn("Worker will use CPUExecutionProvider (reliable). Run "
+                     "396_amd_rocm_stack.sh, reboot, then re-run this installer for the ROCm path.")
 
     packages = BASE_PACKAGES + (NVIDIA_PACKAGES if hardware == "nvidia" else ())
-    # Gentle AMD hint, never mandatory (keeps install reliable without ROCm).
-    if hardware == "amd" and not shutil.which("rocm-smi") and not Path("/dev/kfd").exists():
-        log_warn("No ROCm stack found; worker will use CPUExecutionProvider (reliable).")
+    if worker_ort == "rocm":
+        # The worker reads this through system-site-packages; installing it
+        # up front keeps the venv step's guard happy.
+        packages += (ROCM_SYSTEM_PACKAGE,)
 
     install_pacman_packages(packages, args.skip_pacman)
 
@@ -578,15 +700,16 @@ def main(argv: list[str]) -> int:
             shutil.copy2(SOURCE_DIR / name, stage / name)
         for name in ("dusky_main.py", "dusky_worker.py", "dusky_trigger.py", "dusky_rec_indicator.py", "dusky_verify.sh"):
             os.chmod(stage / name, 0o755)
-        main_py, worker_py = install_python_environments(stage, hardware)
+        main_py, worker_py = install_python_environments(stage, hardware, worker_ort, rocm)
         silero_hash = download_silero(stage, args.silero_sha256)
-        verify_namespaces(main_py, worker_py, hardware)
+        verify_namespaces(main_py, worker_py, worker_ort)
         verify_cpu_vad(main_py, stage / "models" / "silero_vad.onnx")
         model_dir = Path(args.model_dir).expanduser() if args.model_dir else DEFAULT_MODEL_ROOT / args.model
         prefetch_model(worker_py, args.model, model_dir, args.quantization)
         config: JsonObject = {
             "schema_version": SCHEMA_VERSION,
             "hardware": hardware,
+            "worker_ort": worker_ort,
             "model": args.model,
             "model_dir": str(model_dir),
             "quantization": None if args.quantization in ("none", "fp32") else args.quantization,
@@ -622,16 +745,18 @@ def main(argv: list[str]) -> int:
         cfg_path = stage / "config.json"
         cfg_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
         os.chmod(cfg_path, 0o600)
-        report = verify_worker(worker_py, stage, hardware, args.gpu_device, cfg_path)
+        report = verify_worker(worker_py, stage, hardware, args.gpu_device, cfg_path,
+                                   worker_ort, (rocm or {}).get("hsa_override", ""))
         manifest = {
             "schema_version": SCHEMA_VERSION, "hardware": hardware, "detected": detected,
+            "worker_ort": worker_ort, "rocm": rocm,
             "kernel": platform.release(), "python": sys.version.split()[0],
             "silero_sha256": silero_hash, "model": args.model,
             "self_test": report, "time": int(time.time()),
         }
         (stage / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
         backup = deploy_stage(stage)
-        install_entrypoints()
+        install_entrypoints((rocm or {}).get("hsa_override", ""))
         if backup and backup.exists():
             shutil.rmtree(backup, ignore_errors=True)
         log_ok(f"Dusky STT installed ({hardware}) at {APP_DIR}.")

--- a/user_scripts/tts_stt/dusky_parakeet/dusky_worker.py
+++ b/user_scripts/tts_stt/dusky_parakeet/dusky_worker.py
@@ -71,9 +71,10 @@ def fail(msg: str, code: int = 2) -> None:
 def assert_worker_namespace(hardware: str) -> None:
     owners = sorted(set(importlib.metadata.packages_distributions().get("onnxruntime", [])))
     expected = ["onnxruntime-gpu"] if hardware == "nvidia" else ["onnxruntime"]
-    # AMD experimental wheels (onnxruntime-migraphx/rocm) still export
-    # "onnxruntime", so accept them on amd but never on nvidia/cpu strict paths.
-    if hardware == "amd" and owners == ["onnxruntime"]:
+    # AMD paths: the plain CPU wheel ("onnxruntime") and AMD's ROCm wheels
+    # ("onnxruntime-rocm", from repo.radeon.com) both export the
+    # "onnxruntime" module -- accept either on amd, never on nvidia/cpu.
+    if hardware == "amd" and owners in (["onnxruntime"], ["onnxruntime-rocm"], ["onnxruntime-migraphx"]):
         return
     if owners != expected:
         fail(f"Worker ORT namespace must be {expected}, found {owners}")


### PR DESCRIPTION
this is so arch has better ml capabilities out of the box. the ai tooling here was mostly cpu-ish unless you had nvidia, so now every vendor gets its native stack: rocm on amd, cuda on nvidia, gpu builds of the tools that were already here.

- lib/gpu_detect.sh so all the new scripts agree on what hardware is present (same detection as 380)
- 396 rocm stack for amd, 397 cuda toolkit, 398 automates the nvidia boot steps 380 used to just print (mkinitcpio modules + nvidia_drm.modeset=1, this one's on by default since it fixes wayland black screens)
- 399 installs ollama-cuda/ollama-rocm instead of cpu ollama, and llama.cpp with the vendor ggml backend (ggml-cuda / ggml-hip / ggml-vulkan, all straight from extra), plus a llama-server user unit (openai api on 127.0.0.1:8081, not autostarted). lm studio behind a flag
- 400/401/402 training (torch matched to vendor + transformers/peft/trl + unsloth), vllm serving, jupyter/vscode lab, plus dusky-ml-doctor health check
- parakeet now actually uses the amd gpu when rocm is there (arch's python-onnxruntime-rocm through a system-site-packages worker venv, same source kokoro's --rocm-source arch uses)
- 409 intel mac quirks (wifi, fn keys, sensors)

the heavy stuff is commented out in 01_main.toml so a default install doesn't quietly download 15 GiB of rocm, uncomment to opt in. cuda is nvidia only and rocm is amd only, that's just how it is.

**testing** — beyond shellcheck/compile/toml checks, i ran the scripts for real on an arch install in a container: 399 really installed ollama + llama-cpp + ggml-vulkan from extra and dropped the unit files in place, 400 really built the venv and pulled torch + transformers + peft + trl (import torch works, doctor reports it all), 396/397/398/409 no-op politely on hardware they don't apply to. i also audited every package name against extra and the aur, which is where the fun came from: llama.cpp is llama-cpp + ggml backends on arch, hipcc lives inside hip-runtime-amd, broadcom-wl-dkms moved to extra, cuda-tools doesn't exist, and paru has no --usepkg flag. the vendor-gated branches fail loudly with instructions instead of silently falling back.

docs in user_scripts/arch_setup_scripts/ML_STACK.md

(ps: commits come from hamstergamerszhang@gmail.com, i don't know why i have a hamster email either)
