### PR TITLE
add render to the default user groups

### DIFF
--- a/user_scripts/arch_setup_scripts/scripts/473_add_user_to_group.sh
+++ b/user_scripts/arch_setup_scripts/scripts/473_add_user_to_group.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # Easily add or remove groups from this array.
 # Separate each group with a space.
 
-TARGET_GROUPS=(wheel input audio video storage optical network lp power games rfkill)
+TARGET_GROUPS=(wheel input audio video render storage optical network lp power games rfkill)
 
 AUTO_MODE=0
 


### PR DESCRIPTION
the one-liner you suggested: render in 473's TARGET_GROUPS, so users get DRI render node access (gpu compute, rocm/kfd, vaapi) without doing it by hand.

thanks for taking the time to go through the big one, and for the honest reasoning on it -- no hard feelings, it's your call to make. this one should be painless to test.
